### PR TITLE
Added newline to the Hello World example

### DIFF
--- a/patterns/01_helloworld/GCC.s
+++ b/patterns/01_helloworld/GCC.s
@@ -1,7 +1,7 @@
 	.file	"1_1.c"
 	.section	.rodata
 .LC0:
-	.string	"hello, world"
+	.string	"hello, world\n"
 	.text
 	.globl	main
 	.type	main, @function

--- a/patterns/01_helloworld/GCC_one_more.tex
+++ b/patterns/01_helloworld/GCC_one_more.tex
@@ -40,7 +40,7 @@ f1              proc near
 s               = dword ptr -1Ch
 
                 sub     esp, 1Ch
-                mov     [esp+1Ch+s], offset s ; "world"
+                mov     [esp+1Ch+s], offset s ; "world\n"
                 call    _puts
                 add     esp, 1Ch
                 retn
@@ -58,7 +58,7 @@ s               = dword ptr -1Ch
 f2              endp
 
 aHello          db 'hello '
-s               db 'world',0
+s               db 'world',0xa,0
 \end{lstlisting}
 
 \RU{Действительно: когда мы выводим строку}\EN{Indeed: when we print the ``hello world'' string}, 

--- a/patterns/01_helloworld/GCC_refined.s
+++ b/patterns/01_helloworld/GCC_refined.s
@@ -1,5 +1,5 @@
 .LC0:
-	.string	"hello, world"
+	.string	"hello, world\n"
 main:
 	pushl	%ebp
 	movl	%esp, %ebp

--- a/patterns/01_helloworld/GCC_x64.lst
+++ b/patterns/01_helloworld/GCC_x64.lst
@@ -1,6 +1,6 @@
 .text:00000000004004D0                  main  proc near
 .text:00000000004004D0 48 83 EC 08      sub     rsp, 8
-.text:00000000004004D4 BF E8 05 40 00   mov     edi, offset format ; "hello, world"
+.text:00000000004004D4 BF E8 05 40 00   mov     edi, offset format ; "hello, world\n"
 .text:00000000004004D9 31 C0            xor     eax, eax
 .text:00000000004004DB E8 D8 FE FF FF   call    _printf
 .text:00000000004004E0 31 C0            xor     eax, eax

--- a/patterns/01_helloworld/GCC_x64.s.m4
+++ b/patterns/01_helloworld/GCC_x64.s.m4
@@ -1,7 +1,7 @@
-include(`commons.m4').string	"hello, world"
+include(`commons.m4').string	"hello, world\n"
 main:
 	sub	rsp, 8
-	mov	edi, OFFSET FLAT:.LC0 ; "hello, world"
+	mov	edi, OFFSET FLAT:.LC0 ; "hello, world\n"
 	xor	eax, eax  ; _numvecreg
 	call	printf
 	xor	eax, eax

--- a/patterns/01_helloworld/GCC_x86.tex
+++ b/patterns/01_helloworld/GCC_x86.tex
@@ -21,7 +21,7 @@ var_10          = dword ptr -10h
                 mov     ebp, esp
                 and     esp, 0FFFFFFF0h
                 sub     esp, 10h
-                mov     eax, offset aHelloWorld ; "hello, world"
+                mov     eax, offset aHelloWorld ; "hello, world\n"
                 mov     [esp+10h+var_10], eax
                 call    _printf
                 mov     eax, 0

--- a/patterns/01_helloworld/MSVC_x64.asm
+++ b/patterns/01_helloworld/MSVC_x64.asm
@@ -1,4 +1,4 @@
-$SG2989	DB	'hello, world', 00H
+$SG2989	DB	'hello, world', 0AH, 00H
 
 main	PROC
 	sub	rsp, 40

--- a/patterns/01_helloworld/MSVC_x86.tex
+++ b/patterns/01_helloworld/MSVC_x86.tex
@@ -11,7 +11,7 @@ cl 1.cpp /Fa1.asm
 
 \begin{lstlisting}[caption=MSVC 2010]
 CONST	SEGMENT
-$SG3830	DB	'hello, world', 00H
+$SG3830	DB	'hello, world', 0AH, 00H
 CONST	ENDS
 PUBLIC	_main
 EXTRN	_printf:PROC

--- a/patterns/01_helloworld/hw.c
+++ b/patterns/01_helloworld/hw.c
@@ -2,6 +2,6 @@
 
 int main() 
 {
-    printf("hello, world");
+    printf("hello, world\n");
     return 0;
 };

--- a/patterns/01_helloworld/hw_2.c
+++ b/patterns/01_helloworld/hw_2.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-const char $SG3830[]="hello, world";
+const char $SG3830[]="hello, world\n";
 
 int main() 
 {


### PR DESCRIPTION
How about adding a newline to the "Hello, World" example? Most systems use line-buffering by default, and printf would not actually print that string until a newline is reached, or a block is flushed if line-buffering is enabled.