### PR TITLE
1st italian draft + typos (ENG) + doubts (ENG)

### DIFF
--- a/patterns/015_prolog_epilogue/main.tex
+++ b/patterns/015_prolog_epilogue/main.tex
@@ -2,4 +2,4 @@
 \ES{\input{patterns/015_prolog_epilogue/main_ES}}
 \PTBR{\input{patterns/015_prolog_epilogue/main_PTBR}}
 \RU{\input{patterns/015_prolog_epilogue/main_RU}}
-
+\ITA{\input{patterns/015_prolog_epilogue/main_ITA}}

--- a/patterns/015_prolog_epilogue/main_ITA.tex
+++ b/patterns/015_prolog_epilogue/main_ITA.tex
@@ -1,0 +1,38 @@
+\chapter{Prologo ed epilogo delle funzioni}
+\label{sec:prologepilog}
+\myindex{Function epilogue}
+\myindex{Function prologue}
+
+Il prologo (o preambolo) di una funzione e' una sequenza di istruzioni all'inizio della funzione stessa.
+Spesso ha una forma simile al seguente frammento di codice:
+
+\begin{lstlisting}
+    push    ebp
+    mov     ebp, esp
+    sub     esp, X
+\end{lstlisting}
+
+Cosa fanno queste istruzioni: salvano il valore del registro \EBP,
+impostano il valore del registro \EBP con il valore di \ESP e allocano spazio sullo stack per le variabili locali.
+
+Il valore di \EBP resta costante durante il periodo di esecuzione della funzione, ed e' usato per accede a variabili locali e argomenti.
+Per lo stesso scopo si puo' usare \ESP, ma siccome cambia nel tempo non e' un approccio molto conveniente.
+
+L'epilogo della funzione libera lo spazio allocato nello stack, ripristina il valore nel registro \EBP al suo stato iniziale e restituisce
+il controllo al \gls{chiamante}:
+
+\begin{lstlisting}
+    mov    esp, ebp
+    pop    ebp
+    ret    0
+\end{lstlisting}
+
+% what about calling convention?
+Prologo ed epilogo di funzioni sono solitamente identificati nei disassemblatori per delimitare le funzioni.
+
+\section{\Recursion}
+
+\myindex{\Recursion}
+Epiloghi e prologhi possono avere un effetto negativo sulla performance in caso di ricorsione.
+
+Maggiori informazioni sulla ricorsione in questo libro: \myref{Recursion_and_tail_call}.

--- a/patterns/01_helloworld/ARM/ARM64_ITA.tex
+++ b/patterns/01_helloworld/ARM/ARM64_ITA.tex
@@ -1,0 +1,101 @@
+\subsection{ARM64}
+
+\subsubsection{GCC}
+
+Compiliamo l'esempio con GCC 4.8.1 per ARM64:
+
+\lstinputlisting[numbers=left,label=hw_ARM64_GCC,caption=\NonOptimizing GCC 4.8.1 + objdump]{patterns/01_helloworld/ARM/hw.lst}
+
+In ARM64 non ci sono le modalita' Thumb e Thumb-2, solo ARM, quindi soltanto istruzioni a 32-bit.
+Il numero di registri e' raddoppiato: \myref{ARM64_GPRs}.
+I registri a 64-bit hanno il prefisso \TT{X-} prefixes, mentre le loro parti a 32-bit hanno il prefisso \EMDASH{}\TT{W-}.
+
+\myindex{ARM!\Instructions!STP}
+L'istruzione \TT{STP} (\IT{Store Pair}) 
+salva simultaneamente due registri nello stack: \RegX{29} e \RegX{30}.
+
+Questa istruzione puo' ovviamente salvare la coppia di valori in una posizione arbitraria in memoria, tuttavia in questo caso e'
+specificato il registro \ac{SP} , e di conseguenza la coppia viene salvata nello stack.
+
+I registri ARM64 sono a 64-bit, ognuno di essi ha dimensione pari a 8 bytes, quindi sono necessari 16 bytes per salvare i due registri.
+
+Il punto esclamativo (``!'') dopo l'operando sta a significare che 16 deve esse prima sottratto da \ac{SP} , e solo successivamente
+i valori devono essere scritti nello stack.
+
+Questo e' anche detto \IT{pre-index}.
+Per le differenze tra \IT{post-index} e \IT{pre-index} 
+leggere qui: \myref{ARM_postindex_vs_preindex}.
+
+Quindi, in termini del piu' familiare x86, la prima istruzione e' semplicamente l'analogo della coppia
+\TT{PUSH X29} e \TT{PUSH X30}.
+\RegX{29} in ARM64 e' usato come \ac{FP} , e \RegX{30} 
+come \ac{LR}, e questo spiega perche' sono salvati nel prologo di funzione e ripristinati nell'epilogo.
+
+La seconda istruzione copia \ac{SP} in \RegX{29} (o \ac{FP}).
+Cio' viene fatto per impostare lo stack frame della funzione.
+
+\label{pointers_ADRP_and_ADD}
+\myindex{ARM!\Instructions!ADRP/ADD pair}
+Le istruzioni \TT{ADRP} e \ADD sono usate per inserire
+l'indirizzo della stringa \q{Hello!} nel registro \RegX{0} , 
+poiche' il primo argomento della funzione viene passato in questo registro.
+
+Non esiste alcun tipo di istruzione in ARM in grado di salvare un numero molto grande in un registro (perche' la lunghezza delle
+istruzioni e' limitata a 4 byte, maggiori informazioni qui: \myref{ARM_big_constants_loading}).
+Percio' devono essere utilizzate piu' istruzioni. La prima (\TT{ADRP}) , scrive l'indirizzo della pagina di 4KiB (4KiB page)
+,in cui si trova la stringa, nel registro \RegX{0}, e la seconda (\ADD) aggiunge semplicemente il resto dell'indirizzo.
+Maggiori informazioni su questo tema: \myref{ARM64_relocs}.
+
+\TT{0x400000 + 0x648 = 0x400648}, e vediamo la nostra C-string \q{Hello!} nel \TT{.rodata} data segment a questo indirizzo.
+
+\myindex{ARM!\Instructions!BL}
+
+\puts viene chiamata subito dopo usando l'istruzione \TT{BL}. Questo e' stato gia' discusso: \myref{puts}.
+
+\MOV scrive 0 in \RegW{0}. 
+\RegW{0} e' la parte bassa a 32 bits del registro a 64-bit \RegX{0}:
+
+\input{ARM_X0_register}
+
+Il risultato della funzione e' restituito tramite \RegX{0} e \main restituisce 0, quindi e' cosi' che viene preparato 
+il valore da restituire.
+Ma perche' usare la parte a 32-bit?
+
+Perche' il tipo \Tint in ARM64, esattamente come in x86-64, e' a 32-bit, per maggiore compatibilita'.
+Quindi se una funzione restituisce un \Tint a 32-bit, solo la parte piu' bassa a 32 bits del registro \RegX{0} sara' valorizzata.
+
+Per verificare quanto detto, cambiamo leggermente l'esempio e ricompiliamolo.
+Adesso \main restituisce un valore a 64-bit:
+
+\begin{lstlisting}[caption=\main returning a value of \TT{uint64\_t} type]
+#include <stdio.h>
+#include <stdint.h>
+
+uint64_t main()
+{
+        printf ("Hello!\n");
+        return 0;
+}
+\end{lstlisting}
+
+Il risultato e' lo stesso, ma quell'istruzione MOV adesso appare cosi': 
+
+\begin{lstlisting}[caption=\NonOptimizing GCC 4.8.1 + objdump]
+  4005a4:       d2800000        mov     x0, #0x0                        // #0
+\end{lstlisting}
+
+\myindex{ARM!\Instructions!LDP}
+
+\INS{LDP} (\IT{Load Pair}) infine riprisina i registri \RegX{29} e \RegX{30}.
+
+Non c'e' il punto esclamativo dopo l'istruzione: cio' implica che il valore viene prima caricato dallo stack, e solo successivamente 
+\ac{SP} e' incrementato di 16.
+Cio' e' detto \IT{post-index}.
+
+\myindex{ARM!\Instructions!RET}
+Una nuova istruzione e' apparsa in ARM64: \RET. 
+Funziona esattamente come \TT{BX LR}, con l'aggiunta di uno speciale \IT{hint} bit, che informa la \ac{CPU}
+del fatto che si tratta di un ritorno da una funzione, e non soltanto una normale istruzione jump, cosi' che possa 
+essere eseguita in modo ottimale.
+
+A causa della semplicita' della funzione, GCC con le opzioni di ottimizzazione genera esattamente lo stesso codice.

--- a/patterns/01_helloworld/ARM/keil_T_ITA.tex
+++ b/patterns/01_helloworld/ARM/keil_T_ITA.tex
@@ -1,0 +1,60 @@
+\subsection{\NonOptimizingKeilVI (\ThumbMode)}
+
+Compiliamo lo stesso esempio usando Keil in Thumb mode:
+
+\begin{lstlisting}
+armcc.exe --thumb --c90 -O0 1.c 
+\end{lstlisting}
+
+Otteniamo (in \IDA):
+
+\begin{lstlisting}[caption=\NonOptimizingKeilVI (\ThumbMode) + \IDA]
+.text:00000000             main
+.text:00000000 10 B5          PUSH    {R4,LR}
+.text:00000002 C0 A0          ADR     R0, aHelloWorld ; "hello, world"
+.text:00000004 06 F0 2E F9    BL      __2printf
+.text:00000008 00 20          MOVS    R0, #0
+.text:0000000A 10 BD          POP     {R4,PC}
+
+.text:00000304 68 65 6C 6C+aHelloWorld  DCB "hello, world",0    ; DATA XREF: main+2
+\end{lstlisting}
+
+Possiamo facilmente individuare gli opcode a 2-byte (16-bit). Questo e', come gia' detto, Thumb.
+\myindex{ARM!\Instructions!BL}
+L'istruzione \TT{BL} , tuttavia, e' fatta da due istruzioni a 16-bit.
+Cio' accade perche' e' impossibile caricare un offset per la funzione \printf usando il poco spazio a disposizione in un opcode a 16-bit.
+Pertanto la prima istruzione a 16-bit carica i 10 bit alti ( the higher 10 bits) dell' offset e la seconda istruzione carica
+gli 11 bit bassi (the lower 11 bits) dell'offset.
+
+% TODO:
+% BL has space for 11 bits, so if we don't encode the lowest bit,
+% then we should get 11 bits for the upper half, and 12 bits for the lower half.
+% And the highest bit encodes the sign, so the destination has to be within
+% \pm 4M of current_PC.
+% This may be less if adding the lower half does not carry over,
+% but I'm not sure --all my programs have 0 for the upper half,
+% and don't carry over for the lower half.
+% It would be interesting to check where __2printf is located relative to 0x8
+% (I think the program counter is the next instruction on a multiple of 4
+% for THUMB).
+% The lower 11 bytes of the BL instructions and the even bit are
+% 000 0000 0110 | 001 0010 1110 0 = 000 0000 0110 0010 0101 1100 = 0x00625c,
+% so __2printf should be at 0x006264.
+% But if we only have 10 and 11 bits, then the offset would be:
+% 00 0000 0110 | 01 0010 1110 0 = 0 0000 0011 0010 0101 1100 = 0x00325c,
+% so __2printf should be at 0x003264.
+% In this case, though, the new program counter can only be 1M away,
+% because of the highest bit is used for the sign.
+
+Come gia' detto, tutte le istruzione in Thumb mode hanno dimensione pari a 2 bytes (o 16 bits).
+Cio' implica che e' impossibile trovare un'istruzione Thumb-instruction ad un indirizzo dispari.
+Secondo quanto detto, l'ultimo bit dell'indirizzo puo' essere omesso nell'encoding delle istruzioni.
+
+Per riassumere, l'istruzione Thumb \TT{BL} puo' codificare un indirizzo in $current\_PC \pm{}\approx{}2M$.
+
+\myindex{ARM!\Instructions!PUSH}
+\myindex{ARM!\Instructions!POP}
+Riguardo le altre istruzioni nella funzione: \PUSH and \POP qui funzionano come \TT{STMFD}/\TT{LDMFD} con
+l'unica differenza che il registro \ac{SP} in questo caso non e' menzionato esplicitamente.
+\TT{ADR} funziona esattamente come nell'esempio precedente.
+\TT{MOVS} scrive 0 nel registro \Reg{0} per restituire zero.

--- a/patterns/01_helloworld/ARM/xcode_ARM_ITA.tex
+++ b/patterns/01_helloworld/ARM/xcode_ARM_ITA.tex
@@ -1,0 +1,69 @@
+\subsection{\OptimizingXcodeIV (\ARMMode)}
+
+Xcode 4.6.3 senza ottimizzazioni produce un sacco di codice ridondante, percio' studieremo l'output ottimizzato in cui le 
+le istruzioni sono il meno possibile, settando lo switch del compilatore \Othree.
+
+\begin{lstlisting}[caption=\OptimizingXcodeIV (\ARMMode)]
+__text:000028C4             _hello_world
+__text:000028C4 80 40 2D E9   STMFD           SP!, {R7,LR}
+__text:000028C8 86 06 01 E3   MOV             R0, #0x1686
+__text:000028CC 0D 70 A0 E1   MOV             R7, SP
+__text:000028D0 00 00 40 E3   MOVT            R0, #0
+__text:000028D4 00 00 8F E0   ADD             R0, PC, R0
+__text:000028D8 C3 05 00 EB   BL              _puts
+__text:000028DC 00 00 A0 E3   MOV             R0, #0
+__text:000028E0 80 80 BD E8   LDMFD           SP!, {R7,PC}
+
+__cstring:00003F62 48 65 6C 6C+aHelloWorld_0  DCB "Hello world!",0
+\end{lstlisting}
+
+Le istruzioni \TT{STMFD} e \TT{LDMFD} ci sono gia' familiari.
+
+\myindex{ARM!\Instructions!MOV}
+
+L'istruzione \MOV scrive il numero \TT{0x1686} nel registro \Reg{0} .
+Questo e' l'offset che punta alla stringa \q{Hello world!} .
+
+Il registro \TT{R7} (per come standardizzato in \cite{IOSABI}) e' un frame pointer. Maggiori informazioni in basso.
+
+\myindex{ARM!\Instructions!MOVT}
+L'istruzione \TT{MOVT R0, \#0} (MOVe Top) scrive 0 nei 16 bit alti (higher 16 bits) del registro.
+Il problema qui e' che l'istruzione generico \MOV in ARM mode potrebbe scrivere solo i 16 bit bassi del registro.
+
+Ricorda che tutti gli opcode delle istruzioni in ARM mode sono limitati ad una lunghezza di 32 bit. Ovviamente questa limitazione non riguarda lo spostamento dei dati tra registri.
+E questo spiega perche' esiste l'istruzione aggiuntiva \TT{MOVT} per scrivere nelle parti alte (da 16 a 31, inclusi).
+Il suo uso qui e' comunque ridondante, perche' l'istruzione \TT{MOV R0, \#0x1686} di sopra ha azzerato la parte alta del registro.
+E' probabilmente un difetto/svista del compilatore.
+% TODO:
+% I think, more specifically, the string is not put in the text section,
+% ie. the compiler is actually not using position-independent code,
+% as mentioned in the next paragraph.
+% MOVT is used because the assembly code is generated before the relocation,
+% so the location of the string is not yet known,
+% and the high bits may still be needed.
+
+\myindex{ARM!\Instructions!ADD}
+L'istruzione \TT{ADD R0, PC, R0} aggiunge il valore in \ac{PC} al valore in \Reg{0}, per calcolare l'indirizzo assoluto della stringa \q{Hello world!}. 
+Come sappiamo, si tratta di \q{\PICcode} e quindi questa correzione risulta essenziale in questo caso.
+
+L'istruzione \INS{BL} chiama la funzione \puts ivece di \printf.
+
+\label{puts}
+\myindex{\CStandardLibrary!puts()}
+\myindex{puts() instead of printf()}
+
+GCC ha sostituito la prima chiamata a \printf con \puts.
+Infatti: \printf con un solo argomento e' quasi analoga a \puts. 
+
+\IT{Quasi}, perche' le due funzioni producono lo stesso risultato solo nel caso in cui la stringa non contiene 
+identificatori di formato (format identifiers) che iniziano con \IT{\%}. 
+In caso contrario l'effetto di queste due funzioni sarebbe diverso
+\footnote{Bisogna anche notare che \puts non richiede un simbolo new line `\textbackslash{}n' alla fine della stringa,
+per questo non lo vediamo qui.}.
+
+Perche' il compilatore ha sostituito \printf con \puts? Probabilment perche' \puts e' piu' veloce
+\footnote{\href{http://go.yurichev.com/17063}{ciselant.de/projects/gcc\_printf/gcc\_printf.html}}. 
+
+Poiche' passa direttamente i caratteri a \gls{stdout} senza confrontare ciascuno di essi con il simbolo \IT{\%}.
+
+Andando avanti, vediamo la familiare istruzione \TT{MOV R0, \#0} che imposta il registro \Reg{0} a to 0.

--- a/patterns/01_helloworld/ARM/xcode_T2_ITA.tex
+++ b/patterns/01_helloworld/ARM/xcode_T2_ITA.tex
@@ -1,0 +1,139 @@
+\subsection{\OptimizingXcodeIV (\ThumbTwoMode)}
+
+Di default Xcode 4.6.3 genera codice per Thumb-2 in questo modo:
+
+\begin{lstlisting}[caption=\OptimizingXcodeIV (\ThumbTwoMode)]
+__text:00002B6C                   _hello_world
+__text:00002B6C 80 B5          PUSH            {R7,LR}
+__text:00002B6E 41 F2 D8 30    MOVW            R0, #0x13D8
+__text:00002B72 6F 46          MOV             R7, SP
+__text:00002B74 C0 F2 00 00    MOVT.W          R0, #0
+__text:00002B78 78 44          ADD             R0, PC
+__text:00002B7A 01 F0 38 EA    BLX             _puts
+__text:00002B7E 00 20          MOVS            R0, #0
+__text:00002B80 80 BD          POP             {R7,PC}
+
+...
+
+__cstring:00003E70 48 65 6C 6C 6F 20+aHelloWorld  DCB "Hello world!",0xA,0
+\end{lstlisting}
+
+% Q: If you subtract 0x13D8 from 0x3E70,
+% you actually get a location that is not in this function, or in _puts.
+% How is PC-relative addressing done in THUMB2?
+% A: it's not Thumb-related. there are just mess with two different segments. TODO: rework this listing.
+
+\myindex{\ThumbTwoMode}
+\myindex{ARM!\Instructions!BL}
+\myindex{ARM!\Instructions!BLX}
+
+Le istruzioni \TT{BL} e \TT{BLX} in Thumb mode, come ricordiamo, sono codificate con una coppia di istruzioni 16-bit.
+In Thumb-2 questi opcode \IT{surrogati} sono estesi in modo tale che le nuove istruzioni possano essere codificate in istruzioni a 32-bit.
+
+Cio' appare ovvio considerando che che gli opcodes delle istruzioni Thumb-2 iniziano sempre con \TT{0xFx} o \TT{0xEx}.
+
+Ma nel listato \IDA 
+i byte degli opcode sono invertiti poiche' per i processori ARM le istruzioni sono codificate secondo il seguente principio: 
+l'ultimo byte viene prima ed e' seguito dal primo byte ( per le modalita' Thumb e Thumb-2 ) 
+oppure, per istruzioni in ARM mode il quarto byte viene prima, seguito dal terzo, dal secondo ed infine dal primo (a causa
+della diversa \gls{endianness}).
+
+Quindi i byte nei listati IDA sono collocati cosi':
+\begin{itemize}
+\item per ARM and ARM64 modes: 4-3-2-1;
+\item per Thumb mode: 2-1;
+\item per coppie di istruzioni a 16-bit in Thumb-2 mode: 2-1-4-3.
+\end{itemize}
+
+\myindex{ARM!\Instructions!MOVW}
+\myindex{ARM!\Instructions!MOVT.W}
+\myindex{ARM!\Instructions!BLX}
+
+Come possiamo vedere, le istruzioni \TT{MOVW}, \TT{MOVT.W} e \TT{BLX} iniziano con \TT{0xFx}.
+
+Ona delle istruzioni Thumb-2 e' \TT{MOVW R0, \#0x13D8} ~---memorizza un valore a 16-bit nella parte bassa del registro \Reg{0} ,
+azzerando i bit piu' alti.
+
+Allo stesso modo, \TT{MOVT.W R0, \#0} ~funziona come \TT{MOVT} nel precedente esempio, ma in Thumb-2.
+
+\myindex{ARM!mode switching}
+\myindex{ARM!\Instructions!BLX}
+
+Tra le altre differenze, l'istruzione \TT{BLX} in questo caso e' usata al posto di \TT{BL}.
+
+La differenza sta nel fatto che, oltre a salvare \ac{RA} nel registro \ac{LR} e passare il controllo alla funzione \puts,
+il processore passa dalla modalita' Thumb/Thumb-2 alla modalita' ARM mode (o viceversa).
+
+Questa istruzione e' posta qui poiche' l'istruzione a cui il controllo viene passato appare cosi' (e' codificata in ARM mode):
+
+\begin{lstlisting}
+__symbolstub1:00003FEC _puts           ; CODE XREF: _hello_world+E
+__symbolstub1:00003FEC 44 F0 9F E5     LDR  PC, =__imp__puts
+\end{lstlisting}
+
+E' essenzialmente un jump alla zona dove l'indirizzo di \puts e' scritto nella imports section.
+
+Il lettore attento potrebbe chiedere: perche' non chiamare \puts proprio nel punto del codice, dove serve effettivamente?
+
+Perche' non e' efficiente in termini di spazio.
+
+\myindex{Dynamically loaded libraries}
+Quasi tutti i programmi utilizzano librerie esterne dinamiche (come le DLL in Windows, .so in *NIX o .dylib in \MacOSX).
+Le librerie dinamiche contengono funzioni usate di frequente, inclusa la funzione C standard \puts.
+
+\myindex{Relocation}
+In un file eseguibile (Windows PE .exe, ELF o Mach-O) e' presente una import section.
+E' una lista di simboli (symbols - funzioni o variabili globali) importata da moduli esterni insieme ai nomi dei moduli stessi.
+
+Il loade dell' \ac{OS} carica tutti i moduli necessari e, mentre enumera gli import symbols nel modulo primario, determina gli indirizzi
+corretti per ciascun simbolo.
+
+Nel nostro caso, \IT{\_\_imp\_\_puts} e' una variabile a 32-bit usata dal loader dell'\ac{OS} per memorizzare l'indirizzo corretto
+della funzione in una libreria esterna. 
+Successivamente l'istruzione \TT{LDR} legge semplicemente il valore a 32-bit da questa variabile e lo scrive nel registro \ac{PC},
+passando il controllo ad esso.
+
+Quindi, per ridurre il tempo necessario al loader dell'\ac{OS} per completare questa procedura, e' una buona idea scrivere l'indirizzo
+di ogni simbolo solo una volta, in un punto dedicato.
+
+\myindex{thunk-functions}
+Inoltre, come abbiamo gia' capito, e' impossibile caricare un valore a 32-bit value in un registro utilizzando solo una istruzione senza
+accesso alla memoria.
+
+Pertanto, la soluzione ottimale e' quella di allocare una funzione separata, che funziona in ARM mode, con il solo scopo di passare
+il controllo alla libreria dinamica e quindi saltare dal codice Thumb a questa piccola funzione di una sola istruzione (and then to jump to this short one-instruction)
+(la cosiddetta \gls{thunk function}).
+
+\myindex{ARM!\Instructions!BL}
+A proposito, nel precedente esempio (compilato per ARM mode) il controllo e' passato da \TT{BL} alla stessa \gls{thunk function}.
+La modalita' del processore pero' non viene cambiata (da cui l'assenza di una \q{X} nella instruction mnemonic).
+
+\subsubsection{More about thunk-functions}
+\myindex{thunk-functions}
+
+Le thunk-functions sono difficili da comprendere, apparentemente, a causa di una denominazione impropria.
+Il modo migliore per capirle e' pensarle come adattatori o convertitori da un tipo di jack ad un altro.
+Ad esempio, un adattatore che consente l'inserimento di una spina elettrica Inglese in una presa Americana, o viceversa.
+Le thunk functions sono a volte anche dette \IT{wrappers}.
+
+Seguono altre descrizioni di queste funzioni:
+
+\begin{framed}
+\begin{quotation}
+“Un pezzo di codice che fornisce un indirizzo:”, secondo to P. Z. Ingerman, 
+che ha inventato le thunks nel 1961 come un modo di legare i parameters alle loro definizioni formali 
+nelle chiamate a procedura in Algol-60. Se una procedura e' chiamata con un'espressione al posto di un parametro formale,
+il compilatore genera una thunk che calcola l'espressione e lascia l'indirizzo del risultato in una posizione standard.
+
+\dots
+
+Microsoft e IBM hanno definito, nei loro sistemi basati su Intel, un “ambiente a 16-bit” 
+(con orrendi segment registers e limitazioni di indirizzi a 64K) e un “ambiente a 32-bit” 
+(con indirizzamento piatto e gestione della memoria semi reale). I due ambienti possono girare contemporaneamente
+sullo stesso computer e OS (grazie a quello che, nel mondo Microsoft, e' detto WOW, acronimo per Windows On Windows).
+MS e IBM hanno entrambi deciso che il processo di di passare da 16- a 32-bit e viceversa e' detto un “thunk”; in Windows 95, 
+esiste anche un tool, THUNK.EXE, detto “thunk compiler”.
+\end{quotation}
+\end{framed}
+% TODO FIXME move to bibliography and quote properly above the quote
+( \href{http://go.yurichev.com/17362}{The Jargon File} )

--- a/patterns/01_helloworld/MIPS/main.tex
+++ b/patterns/01_helloworld/MIPS/main.tex
@@ -1,3 +1,3 @@
 \EN{\input{patterns/01_helloworld/MIPS/main_EN}}
 \RU{\input{patterns/01_helloworld/MIPS/main_RU}}
-
+\ITA{\input{patterns/01_helloworld/MIPS/main_ITA}}

--- a/patterns/01_helloworld/MIPS/main_ITA.tex
+++ b/patterns/01_helloworld/MIPS/main_ITA.tex
@@ -1,0 +1,142 @@
+\section{MIPS}
+
+\subsection{Qualche parola sul \q{global pointer}}
+\label{MIPS_GP}
+
+\myindex{MIPS!\GlobalPointer}
+
+Un importante concetto MIPS e' il \q{global pointer}.
+Come potremmo gia' sapere, ogni ustrizione MIPS ha lunghezza pari a 32 bit, quindi e' impossibile inserire un indirizzo a 32-bit
+in una sola istruzione: deve essere usata una coppia (come ha fatto GCC nell'esempio per il caricamento dell'indirizzo della stringa).
+E' comunque possibile caricare dati da un indirizzo nell'intervallo $register-32768...register+32767$ utilizzando una singola istruzione
+(perche' 16 bit di un signed offset possono essere codificati in una singola istruzione).
+Possiamo quindi allocare per questo scopo un registro e allocare anche un'area a 64KiB per i dati piu' usati.
+Questo registro dedicato e' detto \q{global pointer} e punta in mezzo dall'area di 64KiB.
+Questa area solitamente contiene variabili globali e indirizzi di funzioni importate come \printf, perche' gli sviluppatori di GCC hanno deciso
+che il recupero dell'indirizzo di una funzione deve essere veloce tanto quanto l'esecuzione di una singola istruzione invece di due.
+
+In un file ELF questa area di 64KiB e' collocata parzialmente nelle sezioni .sbss (\q{small \ac{BSS}}) per dati non inizializzati
+e .sdata (\q{small data}) per dati inizializzati.
+
+Cio' implica che il programmatore puo' scegliere a quale dati si possa accedere piu' velocemente e piazzarli nelle sezioni .sdata/.sbss.
+Alcuni programmatori old-school potrebbero ricordarsi del memory model MS-DOS \myref{8086_memory_model} 
+o dei memory manger MS-DOS come XMS/EMS, in cui tutta la memoria era divisa in blocchi da 64KiB.
+
+\myindex{PowerPC}
+
+Questo concetto non e' unicamente di MIPS. Anche PowerPC usa la stessa tecnica.
+
+\subsection{\Optimizing GCC}
+
+Consideriamo il seguente esempio che illustra il concetto di \q{global pointer}.
+
+\lstinputlisting[caption=\Optimizing GCC 4.4.5 (\assemblyOutput),numbers=left]{patterns/01_helloworld/MIPS/hw_O3.s.\LANG}
+
+Come possiamo vedere, il registro \$GP e' settato nel prologo della funzione affinche' punti nel mezzo di questa area.
+Il registro \ac{RA} viene anche salvato sullo stack locale.
+\puts e' usata anche qui al posto di \printf.
+\myindex{MIPS!\Instructions!LW}
+L'indirizzo della funzione \puts e' caticato in \$25 usando \INS{LW} , l'istruzione (\q{Load Word}).
+\myindex{MIPS!\Instructions!LUI}
+\myindex{MIPS!\Instructions!ADDIU}
+Successivamente l'indirizzo della stringa viene caricato in \$4 usando la coppia di istruzioni \INS{LUI} (\q{Load Upper Immediate}) e 
+\INS{ADDIU} (\q{Add Immediate Unsigned Word}).
+\INS{LUI} setta i 16 bit alti del registro (da cui la parola \q{upper} nel nome dell'istruzione) e \INS{ADDIU} aggiunge
+i 16 bit piu' bassi dell'indirizzo.
+
+\INS{ADDIU} segue \INS{JALR} (ti ricordi dei \IT{branch delay slots}?).
+Il registro \$4 e' anche detto \$A0, e' usato per passare il primo argomento di una funzione
+\footnote{La tabella dei registri MIPS e' riportata in appendice \myref{MIPS_registers_ref}}.
+
+\myindex{MIPS!\Instructions!JALR}
+
+\INS{JALR} (\q{Jump and Link Register}) salta all'indirizzo memorizzato nel registro \$25 register (indirizzo di \puts) 
+salvando l'indirizzo della prossima istruzione (LW) in \ac{RA}.
+Questo e' molto simile ad ARM.
+Oh, e una cosa importate e' che l'indirizzo salvato in \ac{RA} non e' l'indirizzo della prossima istruzione (perche' e' in un 
+\IT{delay slot} e viene eseguito prima prima dell'istruzione jump),
+ma l'indirizzo dell'istruzione dopo la prossima (dopo il \IT{delay slot}).
+
+Quindi, $PC + 8$ viene scritto in \ac{RA} durante l'esecuzione di \TT{JALR}, nel nostro caso, questo e' l'indirizzo dell'istruzione 
+\INS{LW} successiva a \INS{ADDIU}.
+
+\INS{LW} (\q{Load Word}) a riga 20 ripristina \ac{RA} dallo stack locale (questa istruzione e' in effetti parte
+dell'epilogo della funzione).
+
+\myindex{MIPS!\Pseudoinstructions!MOVE}
+
+\INS{MOVE} a riga 22 copia il valore dal registro \$0 (\$ZERO) al \$2 (\$V0).
+\label{MIPS_zero_register}
+
+MIPS ha un registro \IT{costante}, il cui valore e' sempre zero.
+Apparentemente, gli sviluppatori MIPS hanno pensato che zero e' la costante piu' usata in programmazione, quindi usiamo il registro \$0
+ ogni volta che serve il valore zero.
+
+Un altro fatto interessante e' che in MIPS non c'e' un'istruzione che trasferisce dati tra registri.
+Infatti, \TT{MOVE DST, SRC} e' \TT{ADD DST, SRC, \$ZERO} ($DST=SRC+0$), che fa la stessa cosa.
+Apparentemente gli sviluppatori MIPS desideravano avere una tabella di opcode compatta.
+Questo non significa che un'addizione si verifichi per ogni istruzione \INS{MOVE}.
+Molto probabilmente, la \ac{CPU} ottimizza queste pseudoistruzioni e la \ac{ALU} non viene mai usata.
+
+\myindex{MIPS!\Instructions!J}
+
+\INS{J} a riga 24 salta all'indirizzo in \ac{RA}, effettuando di fatti il ritorno dalla funzione.
+\INS{ADDIU} dopo J e' in effetti eseguita prima di J (ricordi i \IT{branch delay slots}?) e fa parte dell'epilogo della funzione.
+Ecco anche il listato generato da \IDA. Ogni registro qui ha il suo pseudonimo:
+
+\lstinputlisting[caption=\Optimizing GCC 4.4.5 (\IDA),numbers=left]{patterns/01_helloworld/MIPS/hw_O3_IDA.lst.\LANG}
+
+L'istruzione alla riga 15 salva il valore di GP sullo stack locale, e questa istruzione manca misteriosamente dal listato prodotto da GCC, forse per un errore di GCC
+\footnote{Apparentemente, le funzioni che generano i listati non sono fondamentali per gli utenti GCC, quindi qualche errore
+non ancora corretto puo' esserci.}.
+Il valore di GP deve essere infatti salvato, perche' ogni funzione puo' usare la sua finestra dati da 64KiB.
+Il registro contenente l'indirizzo di \puts e' chiamato \$T9, perche' i registri con il prefisso T- sono detti 
+\q{temporaries} ed il loro contenuto puo' non essere preservato.
+
+\subsection{\NonOptimizing GCC}
+
+\NonOptimizing GCC e' piu' verboso.
+
+\lstinputlisting[caption=\NonOptimizing GCC 4.4.5 (\assemblyOutput),numbers=left]{patterns/01_helloworld/MIPS/hw_O0.s.\LANG}
+
+Qui vediamo che il registro FP e' usato come un puntatore allo stack frame.
+Vediamo anche 3 \ac{NOP}s.
+Di cui il secondo e terzo seguono all'istruzione branch.
+Forse GCC aggiunge sempre \ac{NOP}s (a causa dei \IT{branch delay slots}) dopo le istruzioni branch
+e successivamente, se le ottimizzazioni sono attivate, forse li elimina.
+Quindi in questo caso sono rimasti.
+
+Ecco anche il listato \IDA:
+
+\lstinputlisting[caption=\NonOptimizing GCC 4.4.5 (\IDA),numbers=left]{patterns/01_helloworld/MIPS/hw_O0_IDA.lst.\LANG}
+
+\myindex{MIPS!\Pseudoinstructions!LA}
+
+E' interessante notare che \IDA ha riconosciuto la coppia di istruzioni \INS{LUI}/\INS{ADDIU} e le ha fusae in un'unica pseudoistruzione 
+\INS{LA} (\q{Load Address}) a riga 15.
+Possiamo anche vedere che questa pseudoistruzione e' lunga 8 bytes!
+Questa e' una pseudoistruzione (o \IT{macro}) in quanto non e' una vera istruzione MIPS , ma soltanto un nome comodo per una coppia
+di istruzioni.
+
+\myindex{MIPS!\Pseudoinstructions!NOP}
+\myindex{MIPS!\Instructions!OR}
+
+Un'altra cosa e' che \IDA non ha riconosciuto le istruzioni \ac{NOP} , che sono alle righe 22, 26 e 41.
+E' \TT{OR \$AT, \$ZERO}.
+Essenzialmente, questa istruzione applica l'operazione OR al contenuto del registro \$AT 
+con zero, che e', ovviamente, un'istruzione nulla/inutile.
+MIPS, come molte altre \ac{ISA}, non ha un'istruzione \ac{NOP} propria.
+
+\subsection{Ruolo dello the stack frame in questo esempio}
+
+L'indirizzo della stringa e' passato nel registro.
+Perche' impostare allora ugualmente uno stack locale?
+La ragione sta nel fatto che i valori dei registri \ac{RA} e GP devono essere salvati da qualche parte 
+(poiche' viene chiamata \printf ), e lo stack locale e' usato proprio per questo scopo.
+Se fosse stata una \gls{leaf function}, sarebbe stato possibile fare a meno (disfarsi) del prologo e dell'epilogo,
+ad esempio: \myref{MIPS_leaf_function_ex1}.
+
+\subsection{\Optimizing GCC: carichiamolo in GDB}
+
+\myindex{GDB}
+\lstinputlisting[caption=sample GDB session]{patterns/01_helloworld/MIPS/O3_GDB.txt}

--- a/patterns/02_stack/01_saving_ret_addr.tex
+++ b/patterns/02_stack/01_saving_ret_addr.tex
@@ -1,4 +1,4 @@
 \EN{\input{patterns/02_stack/01_saving_ret_addr_EN}}
 \RU{\input{patterns/02_stack/01_saving_ret_addr_RU}}
 \PTBR{\input{patterns/02_stack/01_saving_ret_addr_PTBR}}
-
+\ITA{\input{patterns/02_stack/01_saving_ret_addr_ITA}}

--- a/patterns/02_stack/01_saving_ret_addr_ITA.tex
+++ b/patterns/02_stack/01_saving_ret_addr_ITA.tex
@@ -1,0 +1,105 @@
+\subsection{Salvare l'indirizzo di ritorno della funzione}
+
+\subsubsection{x86}
+
+\myindex{x86!\Instructions!CALL}
+Quando si chiama una funzione con l'istruzione \CALL, l'indirizzo del punto esattamente dopo la \CALL viene salvato nello stack, e successivamente
+viene eseguito un jump non condizionale all'indirizzo dell'operando di CALL.
+
+\myindex{x86!\Instructions!PUSH}
+\myindex{x86!\Instructions!JMP}
+L'istruzione \CALL e' equivalente alla coppia di istruzioni \INS{PUSH indirizzo\_dopo\_call / JMP operando}.
+
+\myindex{x86!\Instructions!RET}
+\myindex{x86!\Instructions!POP}
+\RET preleva un valore dallo stack e effettua un jump ad esso~--- cio' equivale alla coppia di istruzioni \TT{POP tmp / JMP tmp}.
+
+\myindex{\Stack!\RU{Переполнение стека}\EN{Stack overflow}\PTBRph{}}
+\myindex{\Recursion}
+
+Riempire lo stack fino allo straripamento e' semplicissimo. Basta ricorrere alla ricorsione eterna:
+
+\begin{lstlisting}
+void f()
+{
+	f();
+};
+\end{lstlisting}
+
+MSVC 2008 riporta il problema:
+
+\begin{lstlisting}
+c:\tmp6>cl ss.cpp /Fass.asm
+Microsoft (R) 32-bit C/C++ Optimizing Compiler Version 15.00.21022.08 for 80x86
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+ss.cpp
+c:\tmp6\ss.cpp(4) : warning C4717: 'f' : recursive on all control paths, function will cause runtime stack overflow
+\end{lstlisting}
+
+\dots ma genera in ogni caso il codice correttamente:
+
+\begin{lstlisting}
+?f@@YAXXZ PROC						; f
+; File c:\tmp6\ss.cpp
+; Line 2
+	push	ebp
+	mov	ebp, esp
+; Line 3
+	call	?f@@YAXXZ				; f
+; Line 4
+	pop	ebp
+	ret	0
+?f@@YAXXZ ENDP						; f
+\end{lstlisting}
+
+\dots Se attiviamo le ottimizzazioni del compilatore (\TT{\Ox} option) il codice ottimizzato non causera' overflow dello stack 
+e funzionera' invece \IT{correttamente}\footnote{sarcasmo, si fa per dire}:
+
+\begin{lstlisting}
+?f@@YAXXZ PROC						; f
+; File c:\tmp6\ss.cpp
+; Line 2
+$LL3@f:
+; Line 3
+	jmp	SHORT $LL3@f
+?f@@YAXXZ ENDP						; f
+\end{lstlisting}
+
+\ifdefined\IncludeGCC
+GCC 4.4.1 genera codice simile in antrambi i casi, senza avvertire del problema.
+\fi
+
+\ifdefined\IncludeARM
+\subsubsection{ARM}
+
+\myindex{ARM!\Registers!Link Register}
+Anche i programmi ARM usano lo stack per salvare gli indirizzi di ritorno, ma lo fanno in maniera diversa.
+Come detto in \q{\HelloWorldSectionName}~(\myref{sec:hw_ARM}),
+As mentioned in 
+il \ac{RA} viene salvato nel \ac{LR} (\gls{link register}).
+Se si presenta comunque la necessita' di chiamare un'altra funzione ed usare il registro \ac{LR} ancora una volta, 
+il suo valore deve essere salvato.
+\myindex{Function prologue}
+Solitamente questo valore e' slvato nel preambolo della funzione.
+
+\myindex{ARM!\Instructions!PUSH}
+\myindex{ARM!\Instructions!POP}
+Spesso vediamo istruzioni come \INS{PUSH {R4-R7,LR}} insieme ad isrtuzioni nell'epilogo come 
+\INS{POP {R4-R7,PC}}---percio' i valori dei registri che saranno usati nella funzione vengono salvati nello stack, incluso \ac{LR}.
+
+\myindex{ARM!Leaf function}
+Ciononostante, se una funzione non chiama al suo interno nessun'altra funzione, in terminologia \ac{RISC} e' detta 
+\IT{\gls{leaf function}}, o funzione foglia.\footnote{\href{http://go.yurichev.com/17064}{infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka13785.html}}. 
+Di conseguenza, le leaf functions non salvano il registro \ac{LR} register (perche' difatti non lo modificano).
+Se una simile funzione e' molto breve e usa un piccolo numero di registri, potrebbe non usare del tutto lo stack. 
+E' quindi possible chiamare le leaf functions senza usare lo stack, cosa che puo' essere piu' veloce che sulle macchine x86 perche' ;a RA< esterna non viene usata per lo stack
+\footnote{Tempo fa, su PDP-11 and VAX, l'istruzione CALL instruction (chiamare altre funzioni) era costosa; poteva richiedere fino al 50\%
+del tempo di esecuzione, ed era quindi consuetudine pensare che avere un grande numero di piccole funzioni fosee un \gls{anti-pattern} \cite[Chapter 4, Part II]{Raymond:2003:AUP:829549}.}.
+Lo stesso principio puo' tornare utile quando la memoria per lo stack non e' stata ancora allocata o non e' disponibile.
+
+Alcuni esempi di funzioni foglia:
+\myref{ARM_leaf_example1}, \myref{ARM_leaf_example2}, 
+\myref{ARM_leaf_example3}, \myref{ARM_leaf_example4}, \myref{ARM_leaf_example5},
+\myref{ARM_leaf_example6}, \myref{ARM_leaf_example7}, \myref{ARM_leaf_example10}.
+\fi % IncludeARM

--- a/patterns/02_stack/02_args_passing_ITA.tex
+++ b/patterns/02_stack/02_args_passing_ITA.tex
@@ -1,0 +1,80 @@
+\subsection{Passaggio di argomenti alle funzioni}
+
+Il modo piu' diffuso di passare parametri in x86 e' detto \q{cdecl}:
+
+\begin{lstlisting}
+push arg3
+push arg2
+push arg1
+call f
+add esp, 12 ; 4*3=12
+\end{lstlisting}
+
+La funzioni chiamate, \Gls{callee}, ricevono i propri argomenti tramite lo stack pointer.
+Quindi e' cosi' che i valori degli arcomenti sono posizionati nello stack prima dell'esecuzione della prima istruzione della funzione \ttf{}:
+
+\begin{center}
+\begin{tabular}{ | l | l | }
+\hline
+ESP & return address \\
+\hline
+ESP+4 & \argument \#1, \MarkedInIDAAs{} \TT{arg\_0} \\
+\hline
+ESP+8 & \argument \#2, \MarkedInIDAAs{} \TT{arg\_4} \\
+\hline
+ESP+0xC & \argument \#3, \MarkedInIDAAs{} \TT{arg\_8} \\
+\hline
+\dots & \dots \\
+\hline
+\end{tabular}
+\end{center}
+
+Per ulteriori informazioni su altri tipi di convenzioni di chiamata (calling conventions), fare riferimento alla sezione~(\myref{sec:callingconventions}).
+Vale la pena notare che non c'e' nulla che obbliga il programmatore a passare gli argomenti attraverso lo stack. Non e' un requisito necessario.
+Si potrebbe implementare un qualunque altro metodo anche senza usare per niente lo stack.
+
+Ad esempio e' possibile allocare spazio per gli argomenti nello \gls{heap}, riempirlo e passarlo ad una funzione tramite un puntatore a questo blocco di memoria, nel registro \EAX.
+E cio' funzionerebbe
+\footnote{Per esempio , nel libro \q{The Art of Computer Programming} di Donald Knuth, 
+nella sezione 1.4.1 dedicata alle subroutines \cite[section 1.4.1]{Knuth:1998:ACP:521463},
+leggiamo che un modo per fornire argomenti ad una subroutine e' quello di sistemarli in memoria semplicemente dopo l'istruzione \JMP che passa il controllo alla subroutine.
+Knuth spiega che questo metodo era particolarmente conveniente sui sistemi IBM System/360.}.
+% FIXME:
+% I am unsure about what this comment means.
+% My guess is that the arguments are put in the memory position after
+% the jump instruction, so you could say:
+% "one way to supply arguments to a subroutine is simply to list them in memory
+% after the \JMP instruction that passes control to the subroutine."
+% Right now, "after" also sounds like it refers to the time after
+% the jump happens, which I think is too late.
+Ad ogni modo, in x86 e ARM e' pratica diffusa e conveniente quella di usare lo stack per questo scopo.
+
+\par
+A proposito, la funzione chiamata (\gls{callee}) non ha alcuna informazione su quanti argomenti sono stati passati.
+Le funzioni C functions con un numero variabile di argomenti (come \printf) determinano questo numero utilizzando i format string specifiers (che iniziano con il simbolo \% ).
+
+Se scriviamo una cosa come:
+
+\begin{lstlisting}
+printf("%d %d %d", 1234);
+\end{lstlisting}
+
+\printf stampera' 1234, e due numeri randomici, che si trovano vicini a 1234 nello stack.
+
+\par
+Questo spiega perche' non e' molto importante come si dichiara la funzione \main : \main, \TT{main(int argc, char *argv[])} oppure \TT{main(int argc, char *argv[], char *envp[])}.
+
+Infatti, il codice \ac{CRT} chiama \main grossomodo cosi':
+
+\begin{lstlisting}
+push envp
+push argv
+push argc
+call main
+...
+\end{lstlisting}
+
+Se si dichiara \main come \main senza arogmenti, saranno comunque presenti nello stack anche se non usati.
+Se si dichiara \main come \TT{main(int argc, char *argv[])},
+si potranno usare i primi due argomenti, ed il terzo restera' \q{invisibile} alla funzione.
+E' inoltre possibile dichiarare anche \TT{main(int argc)}, e funzionera'.

--- a/patterns/02_stack/03_local_vars_ITA.tex
+++ b/patterns/02_stack/03_local_vars_ITA.tex
@@ -1,0 +1,14 @@
+\subsection{Memorizzazione di variabili locali}
+
+Una funzione puo' allocare spazio nello stack per le sue variabili locali, semplicemente decrementando
+lo \gls{stack pointer} verso il basso (indirizzi piu' bassi) dello stack.
+
+% I think here, "stack bottom" means the lowest address in the stack space,
+% but the reader might also think it means towards the top of the stack space,
+% like in a pop, so you might change "towards the stack bottom" to
+% "towards the lowest address of the stack", or just take it out,
+% since "decreasing" also suggests that.
+
+Pertanto l'operazione risulta molto veloce, a prescinedere dal numero di variabili locali definite.
+Anche in questo caso utilizzare lo stack per memorizzare variabili locali non e' un requisito necessario.
+Si possono memorizzare dove si vuole, ma tradizionalmente si fa cosi'.

--- a/patterns/02_stack/04_alloca/main.tex
+++ b/patterns/02_stack/04_alloca/main.tex
@@ -1,4 +1,4 @@
 \EN{\input{patterns/02_stack/04_alloca/main_EN}}
 \RU{\input{patterns/02_stack/04_alloca/main_RU}}
 \PTBR{\input{patterns/02_stack/04_alloca/main_PTBR}}
-
+\ITA{\input{patterns/02_stack/04_alloca/main_ITA}}

--- a/patterns/02_stack/04_alloca/main_ITA.tex
+++ b/patterns/02_stack/04_alloca/main_ITA.tex
@@ -1,0 +1,58 @@
+\subsection{x86: la funzione alloca() }
+\label{alloca}
+\myindex{\CStandardLibrary!alloca()}
+
+\newcommand{\AllocaSrcPath}{C:\textbackslash{}Program Files (x86)\textbackslash{}Microsoft Visual Studio 10.0\textbackslash{}VC\textbackslash{}crt\textbackslash{}src\textbackslash{}intel}
+
+Vale la pena esaminare la funzione \TT{alloca()}
+\footnote{In MSVC, l'implementazione della funzione si trova in \TT{alloca16.asm} e \TT{chkstk.asm} in \TT{\AllocaSrcPath{}}}.
+Questa funzione opera come \TT{malloc()}, ma alloca memoria direttamente nello stack.
+% page break added to prevent "\vref on page boundary" error. it may be dropped in future.
+Il pezzo di memoria allocato non necessita di essere liberato tramite una chiamata alla funzione \TT{free()} function call, \\
+poiche' l'epilogo della funzione (\myref{sec:prologepilog}) ripristina \ESP al suo valore iniziale e la memoria allocata viene semplicemente \IT{abbandonata}.
+Vale anche la pena notare come e' implementata la funzione \TT{alloca()}.
+In termini semplici, questa funzione shifta \ESP in basso, verso la base dello stack, per il numero di byte necessari e setta \ESP  
+per puntare al blocco \IT{allocato}.
+
+Proviamo:
+
+\lstinputlisting{patterns/02_stack/04_alloca/2_1.c}
+
+La funzione \TT{\_snprintf()} opera come \printf, ma invece di inviare il risultato a \gls{stdout} (es. al terminale o console),
+lo scrive nel buffer \TT{buf}. La funzione \puts copia il contenuto di \TT{buf} in \gls{stdout}.
+Ovviamente questo due chiamate potrebbero essere rimpiazzate da una sola chiamata a \printf, ma in questo caso era necessario per illustrare
+l'uso di un piccolo buffer.
+
+\subsubsection{MSVC}
+
+Compiliamo (MSVC 2010):
+
+\lstinputlisting[caption=MSVC 2010]{patterns/02_stack/04_alloca/2_2_msvc.asm}
+
+\myindex{Compiler intrinsic}
+L'unico argomento di \TT{alloca()} e' passato tramite il registro \EAX (anziche' metterlo nello stack)
+\footnote{Questo perche' alloca() e' una "compiler intrinsic" (\myref{sec:compiler_intrinsic}) piuttosto che una funzione normale.
+Una delle ragioni per cui abbiamo bisogno di una funzione separata, invece di un paio di istruzioni nel codice, e' che
+l'implementazione di alloca() di \ac{MSVC} ha anche del codice che legge dalla memoria appena llocata, per far si che l'\ac{OS} effettui il mapping
+della memoria fisica in questa regione della \ac{VM}.
+Dopo la chiamata a \TT{alloca()} , \ESP punta al blocco di 600 byte, ed e' possibile utilizzarlo come memoria per l'array \TT{buf}.}.
+
+\ifdefined\IncludeGCC
+\subsubsection{GCC + \IntelSyntax}
+
+GCC 4.4.1 fa lo stesso senza chiamare funzioni esterne:
+
+\lstinputlisting[caption=GCC 4.7.3]{patterns/02_stack/04_alloca/2_1_gcc_intel_O3.asm.\LANG}
+
+\subsubsection{GCC + \ATTSyntax}
+
+Esaminiamo lo stesso codice, ma in sintassi AT\&T:
+
+\lstinputlisting[caption=GCC 4.7.3]{patterns/02_stack/04_alloca/2_1_gcc_ATT_O3.s}
+
+\myindex{\ATTSyntax}
+The code e' uguale a quello del listato precedente.
+
+A proposito, \INS{movl \$3, 20(\%esp)} corrisponde a \INS{mov DWORD PTR [esp+20], 3} in sintassi Intel.
+In sintassi AT\&T, il formato registro+offset per indirizzare memoria appare come \TT{offset(\%{register})}.
+\fi

--- a/patterns/02_stack/05_SEH.tex
+++ b/patterns/02_stack/05_SEH.tex
@@ -16,3 +16,7 @@ Read more about it: (\myref{sec:SEH}).
 \PTBRph{}: (\myref{sec:SEH}).
 \fi % BRAZILIAN
 
+\ifdefined\ITALIAN
+I record \ac{SEH}, se presenti, sono anch'essi memorizzati nello stack.
+Maggiori informazioni qui: (\myref{sec:SEH}).
+\fi % ITALIAN

--- a/patterns/02_stack/06_BO_protection.tex
+++ b/patterns/02_stack/06_BO_protection.tex
@@ -16,3 +16,8 @@ More about it here~(\myref{subsec:bufferoverflow}).
 Mais sobre aqui~(\myref{subsec:bufferoverflow}).
 \fi
 
+\ifdefined\ITALIAN
+\subsection{Protezione da buffer overflow}
+
+Maggiori informazioni qui~(\myref{subsec:bufferoverflow}).
+\fi

--- a/patterns/02_stack/07_layout_ITA.tex
+++ b/patterns/02_stack/07_layout_ITA.tex
@@ -1,0 +1,16 @@
+\section{Una tipico layout dello stack}
+
+Una disposizione tipica dello stack in un ambiente a 32-bit all'inizio di una funzione, 
+prima dell'esecuzione della sua prima istruzione, appare cosi':
+
+\input{patterns/02_stack/stack_layout}
+
+% I think this only applies to RISC architectures
+% that don't have a POP instruction that only lets you read one value
+% (ie. ARM and MIPS).
+% In x86, the return address is saved before entering the function,
+% and the function does not have the chance to save the frame pointer.
+% Also, you should mention that this is how the stack looks like
+% right after the function prologue,
+% which some readers might think is the first instruction,
+% but is needed to save the frame pointer.

--- a/patterns/02_stack/08_noise/main.tex
+++ b/patterns/02_stack/08_noise/main.tex
@@ -1,3 +1,3 @@
 \EN{\input{patterns/02_stack/08_noise/main_EN}}
 \RU{\input{patterns/02_stack/08_noise/main_RU}}
-
+\ITA{\input{patterns/02_stack/08_noise/main_ITA}}

--- a/patterns/02_stack/08_noise/main_ITA.tex
+++ b/patterns/02_stack/08_noise/main_ITA.tex
@@ -1,0 +1,111 @@
+\section{Rumore nello stack}
+
+In questo libro si fa spesso riferimento a \q{rumore} o \q{spazzatura} (garbage) nello stack o in memoria.
+
+Da dove arrivano?
+Sono cio' che resta dopo l'esecuzione di altre funzioni.
+Un piccolo esempio:
+
+\lstinputlisting{patterns/02_stack/08_noise/st.c}
+
+Compilando si ottiene:
+
+\lstinputlisting[caption=\NonOptimizing MSVC 2010]{patterns/02_stack/08_noise/st.asm}
+
+Il compilatore si lamentera' un pochino\dots
+
+\begin{lstlisting}
+c:\Polygon\c>cl st.c /Fast.asm /MD
+Microsoft (R) 32-bit C/C++ Optimizing Compiler Version 16.00.40219.01 for 80x86
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+st.c
+c:\polygon\c\st.c(11) : warning C4700: uninitialized local variable 'c' used
+c:\polygon\c\st.c(11) : warning C4700: uninitialized local variable 'b' used
+c:\polygon\c\st.c(11) : warning C4700: uninitialized local variable 'a' used
+Microsoft (R) Incremental Linker Version 10.00.40219.01
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+/out:st.exe
+st.obj
+\end{lstlisting}
+
+Ma quando avvieremo il programma \dots
+
+\begin{lstlisting}
+c:\Polygon\c>st
+1, 2, 3
+\end{lstlisting}
+
+Oh, che cosa strana! Non abbiamo impostato il valore di alcuna variabile in \TT{f2()}. 
+Si tratta di valori \q{fantasma} , che si trovano ancora nello stack.
+
+\clearpage
+Carichiamo l'esempio in \olly:
+
+\begin{figure}[H]
+\centering
+\includegraphics[scale=\FigScale]{patterns/02_stack/08_noise/olly1.png}
+\caption{\olly: \TT{f1()}}
+\label{fig:stack_noise_olly1}
+\end{figure}
+
+Quando \TT{f1()} assegna le variabili $a$, $b$ e $c$, i loro valori sono memorizzati all'indirizzo \TT{0x1FF860} e seguenti.
+
+\clearpage
+E quando viene eseguita \TT{f2()}:
+
+\begin{figure}[H]
+\centering
+\includegraphics[scale=\FigScale]{patterns/02_stack/08_noise/olly2.png}
+\caption{\olly: \TT{f2()}}
+\label{fig:stack_noise_olly2}
+\end{figure}
+
+... $a$, $b$ e $c$ di \TT{f2()} si trovano agli stessi indirizzi!
+Nessuno ha ancora sovrascritto quei valori, e a quel punto restano intatti.
+Quindi, affinche' questa strana situazione si verifichi, piu' funzioni devono essere chiamate una dopo l'altra e
+\ac{SP} deve essere uguale ad ogni ingresso nella funzione (ovvero le funzioni devono avere lo stesso numero di argomenti).
+A quel punto le variabili locali si troveranno nelle stesse posizioni nello stack.
+Per riassumere, tutti i valori nello stack (e nelle celle di memoria in generale) hanno valori lasciati li' dall'esecuzione di funzioni precedenti.
+Non sono letteralmente randomici, piuttosto hanno valori non predicibili.
+C'e' un'altra opzione?
+Sarebbe possibile ripulire porzioni dello stack prima di ogni esecuzione di una funzione, ma sarebbe un lavoro extra inutile.
+
+\subsection{MSVC 2013}
+
+L'esempio e' stato compilato con MSVC 2010.
+Un lettore di questo libro ha provato a compilare l'esempio con MSVC 2013, lo ha eseguito, ed ha ottenuto i 3 numeri in ordine inverso:%
+
+\begin{lstlisting}
+c:\Polygon\c>st
+3, 2, 1
+\end{lstlisting}
+
+Perche'?
+Ho compilato anche io l'esempio in MSVC 2013 ed ho visto questo:
+
+
+\begin{lstlisting}[caption=MSVC 2013]
+_a$ = -12						; size = 4
+_b$ = -8						; size = 4
+_c$ = -4						; size = 4
+_f2	PROC
+
+...
+
+_f2	ENDP
+
+_c$ = -12						; size = 4
+_b$ = -8						; size = 4
+_a$ = -4						; size = 4
+_f1	PROC
+
+...
+
+_f1	ENDP
+\end{lstlisting}
+
+Contrariamente a MSVC 2010, MSVC 2013 ha allocato le variabili a/b/c nella funzione \TT{f2()} in ordine inverso.%
+E cio' e' del tutto corretto, perche' lo standard \CCpp non ha una regola che definisce in quale ordine le variabili locali devono essere allocate nello stack.
+La ragione per cui si presenta questa differenza e' che MSVC 2010 ha un solo modo per farlo, mentre MSVC 2013 ha probabilmente subito modifiche all'interno del compilatore, e si comporta quindi in modo leggermente diverso. 

--- a/patterns/02_stack/main.tex
+++ b/patterns/02_stack/main.tex
@@ -1,4 +1,5 @@
 \EN{\input{patterns/02_stack/main_EN}}
 \RU{\input{patterns/02_stack/main_RU}}
 \PTBR{\input{patterns/02_stack/main_PTBR}}
+\ITA{\input{patterns/02_stack/main_ITA}}
 

--- a/patterns/02_stack/main_ITA.tex
+++ b/patterns/02_stack/main_ITA.tex
@@ -1,0 +1,115 @@
+\chapter{\Stack}
+\label{sec:stack}
+\myindex{\Stack}
+
+Lo stack e' una delle strutture dati piu' importanti in informatica
+\footnote{\href{http://go.yurichev.com/17119}{wikipedia.org/wiki/Call\_stack}}.
+
+Tecnicamente, e' soltanto un blocco di memoria nella memoria di un processo insieme al registro \ESP o \RSP in x86 o x86, o il registro \ac{SP} in ARM, come puntatore all'interno di quel blocco.
+
+\myindex{ARM!\Instructions!PUSH}
+\myindex{ARM!\Instructions!POP}
+\myindex{x86!\Instructions!PUSH}
+\myindex{x86!\Instructions!POP}
+Le istruzioni di accesso allo stack piu' usate sono \PUSH e \POP (sia in x86 che in ARM Thumb-mode).
+\PUSH sottrae da \ESP/\RSP/\ac{SP} 4 in modalita' 32-bit (oppur 8 in modalita' 64-bit) e scrive successivamente il contenuto del suo unico operando nell'indirizzo di memoria puntato da \ESP/\RSP/\ac{SP}.
+
+
+\POP e' l'operazione inversa: recupera il dato dalla memoria a cui punta \ac{SP}, lo carica nell'operando dell'istruzione (di solito un registro)
+e successivamente aggiunge 4 (o 8) allo \gls{stack pointer}.
+
+A seguito dell'allocazione dello stack, lo \gls{stack pointer} punta alla base (fondo) dello stack.
+\PUSH decrementa lo \gls{stack pointer} e \POP lo incrementa.
+La base dello stack e' in realta' all'inizio della memoria allocata per il blocco (porzione) dello stack. Sembra strano, ma e' cosi'.
+
+
+\ifdefined\IncludeARM
+ARM supporta stack decrescenti e crescenti.
+
+\myindex{ARM!\Instructions!STMFD}
+\myindex{ARM!\Instructions!LDMFD}
+\myindex{ARM!\Instructions!STMED}
+\myindex{ARM!\Instructions!LDMED}
+\myindex{ARM!\Instructions!STMFA}
+\myindex{ARM!\Instructions!LDMFA}
+\myindex{ARM!\Instructions!STMEA}
+\myindex{ARM!\Instructions!LDMEA}
+
+Ad esempio le istruzioni \ac{STMFD}/\ac{LDMFD}, \ac{STMED}/\ac{LDMED} sono fatte per operare con uno stack decrescente (che cresce verso il basso, inizia con un indirizzo alto e prosegue verso il basso).
+Le istruzioni \ac{STMFA}/\ac{LDMFA}, \ac{STMEA}/\ac{LDMEA} sono fatte per operare con uno stack crescente (che cresce verso l'alto, da un indirizzo basso verso uno piu alto).
+\fi
+
+% It might be worth mentioning that STMED and STMEA write first,
+% and then move the pointer,
+% and that LDMED and LDMEA move the pointer first, and then read.
+% In other words, ARM not only lets the stack grow in a non-standard direction,
+% but also in a non-standard order.
+% Maybe this can be in the glossary, which would explain why E stands for "empty".
+
+\section{Perche' lo stack cresce al contrario?}
+
+Intuitivamente potremmo pensare che lo stack cresca verso l'alto, ovvero verso indirizzi piu' alti, come qualunque altra struttura dati.
+
+La ragione per cui lo stack cresce verso il basso e' probabilmente di natura storica.
+Quando i computer erano talmente grandi da occupare un'intera stanza, era facile dividere la memoria in due parti, una per lo 
+\gls{heap} e l'altra per lo stack.
+Ovviamente non era possibile sapere a priori quanto sarebbero stati grandi lo stack e lo \gls{heap} durante l'esecuzione di un programma,
+e questa soluzione era la piu' semplice.
+
+\input{patterns/02_stack/stack_and_heap}
+
+In \cite{Ritchie74} possiamo leggere:
+
+\begin{framed}
+\begin{quotation}
+The user-core part of an image is divided into three logical segments.
+The program text segment begins at location 0 in the virtual address space.
+During execution, this segment is write-protected and a single copy of it is shared among all processes executing the same program.
+At the first 8K byte boundary above the program text segment in the virtual address space begins a nonshared, writable data segment, the size of which may be extended by a system call.
+Starting at the highest address in the virtual address space is a stack segment, which automatically grows downward as the hardware's stack pointer fluctuates.
+
+Il nucleo utente di una immagine e' diviso in tre segmenti logici.
+Il segmento text del programma inizia in posizione 0 nel virtual address space.
+Durante l'esecuzione questo segmento viene protetto da scrittura, ed una sua singola copia viene condivisa tra i processi che eseguono lo stesso programma.
+Al primo limite di 8K byte dopra il segmento text del programma, nel virtual address space comincia un segmento dati scrivibile, non condiviso, le cui dimensioni possono essere estese da una chiamata di sistema.
+A partire dall'indirizzo piu' alto nel virtual address space c'e' lo stack segment, che automaticammente cresce verso il basso al variare dello stack pointer hardware.
+\end{quotation}
+\end{framed}
+
+Questo ricorda molto come alcuni studenti utilizzino lo stesso quaderno per prendere appunti di due diverse materie:
+gli appunti per la prima materia sono scritti normalmente, e quelli della seconda materia sono scritti a partire dalla fine del quaderno, capovolgendolo.
+Le note si potrebbero "incontrare" da qualche parte in mezzo al quaderno, nel caso in cui non ci sia abbastanza spazio libero.
+
+% I think if we want to expand on this analogy,
+% one might remember that the line number increases as as you go down a page.
+% So when you decrease the address when pushing to the stack, visually,
+% the stack does grow upwards.
+% Of course, the problem is that in most human languages,
+% just as with computers,
+% we write downwards, so this direction is what makes buffer overflows so messy.
+
+\section{Per cosa viene usato lo stack?}
+
+% subsections
+\input{patterns/02_stack/01_saving_ret_addr}
+\input{patterns/02_stack/02_args_passing}
+\EN{\input{patterns/02_stack/03_local_vars_EN}}
+\RU{\input{patterns/02_stack/03_local_vars_RU}}
+\PTBR{\input{patterns/02_stack/03_local_vars_PTBR}}
+\input{patterns/02_stack/04_alloca/main}
+\input{patterns/02_stack/05_SEH}
+\input{patterns/02_stack/06_BO_protection}
+
+\subsection{Deallocazione automatica dei dati nello stack}
+
+Probabilmente la ragione per cui si memorizzano nello stack le variabili locali e i record SEH deriva dal fatto che questi dati vengono "liberati" automaticamente all'uscita dalla funzione,
+usando soltanto un'istruzione per correggere lo stack pointer (spesso e' \ADD).
+Si puo' dire che anche gli argomenti delle funzioni sono deallocati automaticamente alla fine della funzione.
+Invece, qualunque altra cosa memorizzata nello \IT{heap} deve essere deallocata esplicitamente.
+
+% sections
+\EN{\input{patterns/02_stack/07_layout_EN}}
+\RU{\input{patterns/02_stack/07_layout_RU}}
+\PTBR{\input{patterns/02_stack/07_layout_PTBR}}
+\input{patterns/02_stack/08_noise/main}
+\input{patterns/02_stack/exercises}

--- a/patterns/main.tex
+++ b/patterns/main.tex
@@ -46,7 +46,7 @@
 \RU{\chapter{Некоторые базовые понятия}}
 \EN{\chapter{Some basics}}
 \ES{\ESph{}}
-\ITA{\ITAph{}}
+\ITA{\ITAph{Alcune basi teoriche}}
 \PTBR{\PTBRph{}}
 \THA{\THAph{}}
 
@@ -59,6 +59,7 @@
 
 % TODO translate to Russian
 \EN{\input{patterns/numeral_EN}}
+\ITA{\input{patterns/numeral_ITA}}
 
 % chapters
 \input{patterns/00_ret/main}

--- a/patterns/numeral_EN.tex
+++ b/patterns/numeral_EN.tex
@@ -9,7 +9,7 @@ Natural numeral system in digital electronics is binary: 0 is for absence of cur
 How to convert from one system to another?
 
 Positional notation is used almost everywhere, this means, the digit (number placed in single character) has some weight depending on where it is placed.
-If 2 is placed at the leftmost place, it's 2.
+If 2 is placed at the leftmost place, it's 2. % <- shoudln't it be rightmost?
 If it is placed at the place one digit before leftmost, it's 20.
 
 What 1234 stands for?

--- a/patterns/numeral_EN.tex
+++ b/patterns/numeral_EN.tex
@@ -4,7 +4,7 @@
 Humans accustomed to decimal numeral system probably because almost all ones has 10 fingers.
 Nevertheless, number 10 has no significant meaning in science and mathematics.
 Natural numeral system in digital electronics is binary: 0 is for absence of current in wire and 1 for presence.
-10 in binary is 2 in decimal, 100 in binary is 4 in binary and so on.
+10 in binary is 2 in decimal, 100 in binary is 4 in decimal and so on.
 
 How to convert from one system to another?
 

--- a/patterns/numeral_ITA.tex
+++ b/patterns/numeral_ITA.tex
@@ -1,0 +1,132 @@
+% TODO translate
+\section{Sistemi di numerazione}
+
+Gli umani si sono abituati ad usare il sistema numerico decimale probabilmente perche' quasi tutti hanno 10 dita.
+Ciononostante, il numero 10 non ha alcun significato rilevante in scienze e in matematica.
+Il sistema di numerazione naturale nell'elettronica digitale e' il binario: 0 per l'assenza di corrente nel filo e 1 per la presenza.
+10 in binario e' 2 in decimale, 100 in binary is 4 in decimale e cosi' via.
+
+Come si fa a convertire un numero da un sistema ad un altro?
+
+La notazione posizionale e' usata quasi dappertutto. Cio' vuol dire che la cifra (numero in un singolo carattere) ha un "peso" diverso in base alla posizone in cui si trova. 
+Se 2 si trova nella parte piu' a destra del numero, e' 2.
+Se si trova di una posizione piu' a destra, e' 20.
+
+Per cosa sta 1234?
+
+$10^3 \cdot 3 + 10^2 \cdot 2 + 10^1 \cdot 3 + 1 \cdot 4$ = 1234 or 
+$1000 \cdot 3 + 100 \cdot 2 + 10 \cdot 3 + 4 = 1234$
+
+Lo stesso vale per i numeri binari, ma la base e' 2 invece di 10.
+Per cosa sta 101011?
+
+$2^5 \cdot 1 + 2^4 \cdot 0 + 2^3 \cdot 1 + 2^2 \cdot 0 + 2^1 \cdot 1 + 1 \cdot 1 = 43$ or
+$32 \cdot 1 + 16 \cdot 0 + 8 \cdot 1 + 4 \cdot 0 + 2 \cdot 1 + 1 = 43$
+
+La notazione posizionale e' opposta a quella non-posizionale come il sistema numerico Romano.
+Forse l'umanita' ha deciso di passare alla notazione posizionale perche' e' piu' facile effettuare semplici operazioni (addizione, moltiplicazione, etc) a mano su carta.
+
+I numeri binari possono essere addizionati, sotratti e cosi' via, nello stesso modo in cui ci e' stato insegnato a scuola, con l'unica differenza chec si sono solo 2 cifre disponibili.
+
+I numeri binary possono risultare ingombranti quando usati in codici sorgenti e dump, ed in questi casi puo' essere usato il sistema esadecimale.
+
+Il sistema esadecimale usa i numeri 0..9 e 6 lettere latine: A..F.
+Ogni cifra esadecimale occupa 4bit o 4 binary digits, ed e; quindi molto facile convertire da binario a esadecimale e viceversa, anche a mente,
+
+\begin{center}
+\begin{longtable}{ | l | l | l | }
+\hline
+\HeaderColor hexadecimal & \HeaderColor binary & \HeaderColor decimal \\
+\hline
+0	&0000	&0 \\
+1	&0001	&1 \\
+2	&0010	&2 \\
+3	&0011	&3 \\
+4	&0100	&4 \\
+5	&0101	&5 \\
+6	&0110	&6 \\
+7	&0111	&7 \\
+8	&1000	&8 \\
+9	&1001	&9 \\
+A	&1010	&10 \\
+B	&1011	&11 \\
+C	&1100	&12 \\
+D	&1101	&13 \\
+E	&1110	&14 \\
+F	&1111	&15 \\
+\hline
+\end{longtable}
+\end{center}
+
+Come identificare quale sistema viene usato?
+
+I numeri decimali sono solitamente scritti cosi' come sono, es. 1234. Alcuni assembler consentono pero' di aggiungere enfasi al sistema decimale ed il numero puo essere scritto con il suffisso "d": 1234d.
+
+I numeri binari sono a volte preceduti dal prefisso "0b": 0b100110111 (\ac{GCC} non ha un'estensione del linguaggio standard per questo: \url{https://gcc.gnu.org/onlinedocs/gcc/Binary-constants.html}).
+C'e' anche un altro modo: il suffisso "b" suffix, ad esempio: 100110111b.
+Cerchero' di usare il prefisso "0b" per identificare i numeri binari all'interno del libro.
+
+I numeri esadecimali sono preceduti dal prefisso "0x" in \CCpp e altri \ac{PL}s: 0x1234ABCD.
+Oppure hanno il suffisso "h": 1234ABCDh - questo e' il modo comune di rapressentarli negli assembler e nei debugger.
+Se il numero inizia con una cifra A..F, 0 dovrebbe essere aggiunto all'inizio: 0ABCDEFh.
+Cerchero' di usare il prefisso "0x" per identificare i numeri esadecimali all'interno del libro.
+
+E' il caso di imparare a convertire i numeri a mente? Una tabella di numeri decimali ad una cifra puo' essere memorizzata facilmente.
+Per numeri piu' grandi, probabilmente, non e' il caso di tormentarsi.
+
+\subsection{Sistema di numerazione ottale}
+
+Un altro sistema di numerazione molto usato in pasato in programmazione e' l'ottale: ci sono 8 cifre (0..7) e ciascuna e' associata a 3 bit, quindi e' facile convertire da una parte all'altra.
+E' stato comunque rimpiazzato dal sistema esadecimale quasi ovunque, ma sorprendentemente c'e' una utility *NIX usata spesso e da molte persone che ha per argomento un numero ottale: \TT{chmod}.
+
+\myindex{UNIX!chmod}
+Come molti utenti *NIX sanno, l'argomento \TT{chmod} puo' essere un numero di 3 cifre. La prima rappresenta i diritti del proprietario del file, la seconda i diritti del gruppo (a cui il file appartiene), la terza i diritti per chiunque altro.
+E ogni cifra puo' essere rappresentata in forma binaria:
+
+\begin{center}
+\begin{longtable}{ | l | l | l | }
+\hline
+\HeaderColor decimale & \HeaderColor binario & \HeaderColor significato \\
+\hline
+7	&111	&\textbf{rwx} \\
+6	&110	&\textbf{rw-} \\
+5	&101	&\textbf{r-x} \\
+4	&100	&\textbf{r-{}-} \\
+3	&011	&\textbf{-wx} \\
+2	&010	&\textbf{-w-} \\
+1	&001	&\textbf{-{}-x} \\
+0	&000	&\textbf{-{}-{}-} \\
+\hline
+\end{longtable}
+\end{center}
+
+Quindi ogni bit corrisponde ad un flag: read/write/execute.
+
+La ragione per cui sto parlando di \TT{chmod} e' che l'intero numero dell'argomento puo' essere rappresentato in ottale.
+Prendiamo per esempio 664.
+Quando si esegue \TT{chmod 664 file}, si impostano i permessi di lettura/scrittura per il proprietario, il permesso di lettura per il gruppo, e il permesso di lettura per tutti gli altri.
+Convertiamo il numero 664 in ottale a binario, sara' \TT{110100100}, o (in gruppi di 3 bit) \TT{110 100 100}.
+
+Notiamo che ogni tripletta descrive i permessi per proprietario/gruppo/altri (owner/group/others): il primo e' \TT{rw-}, il secondo e' \TT{r--} ed il terzo e' \TT{r--}.
+
+Il sistema ottale era anche molto diffuso nei vecchi computer come PDP-8, perche' una word poteva essere 12, 24 o 36 bit, e questi numeri sono tutti divisibili per 3, quindi il sistema ottale era naturale in quell'ambiente.
+Oggi tutti i computer comuni utilizano word/indirizzi lunghi 16, 32 o 64 bit, e questi numeri sono divisibili per 4, di conseguenza l'esadecimale risulta piu' naturale.
+
+Il sistema ottale e' supportato da tutti i compilatori \CCpp standard.
+Talvolta cio' da' vita a confusione, perche' i numeri ottali sono codificati preponendo uno zero, per esempio 0277 e' 255.
+A volte si potrebbe scrivere per errore "09" invece di 9 , e il compilatore non lo consentirebbe.
+GCC potrebbe presentare un errore del genere: \TT{error: invalid digit "9" in octal constant}.
+
+\subsection{Divisibilita'}
+
+Quando si vede un numero decimale come 120, si puo' velocemente dedurre che e' divisibile per 10, perche' l'ultima cifra e' zero.
+Allo stesso modo, 123400 e' divisibile per 100 perche' le ultime due cifre sono zeri.
+
+
+In maniera simile, il numero esadecimale 0x1230 e' divisible per 0x10 (ovvero 16), 0x123000 e' divisibile per 0x1000 (ovvero 4096), etc.
+
+Il numero binario 0b1000101000 e' dibisibile per 0b1000 (8), etc.
+
+Questa proprieta' puo' essere spesso usata per capire velocemente se la dimensione di un dato blocco di memoria e' "allungata" (padded) per raggiungere un certo confine.
+Per esempio, le sezioni in un file \ac{PE} iniziano quasi sempre ad indirizzi che terminano con 3 zeri esadecimali: 0x41000, 0x10001000, etc.
+La ragione per cui questo accade risiede nel fatto che quasi tutte le sezioni di un \ac{PE} sono allungate per raggiungere un confine di 0x1000 (4096) bytes.


### PR DESCRIPTION
added italian translation draft up to chapter 6.
fixed a typo in patterns/numeral_EN.tex (100 in binary is 4 in binary -> 100 in binary is 4 in decimal).
added a comment in patterns/numeral_EN.tex about a possible typo (or my misinterpretation) in the positional notation section. 