### PR TITLE
Changed a german chapter name to the appropriate german tag

### DIFF
--- a/patterns/main.tex
+++ b/patterns/main.tex
@@ -53,7 +53,7 @@
 
 \RU{\section{Некоторые базовые понятия}}
 \EN{\section{Some basics}}
-\EN{\section{Einige Grundlagen}}
+\DE{\section{Einige Grundlagen}}
 \ES{\ESph{}}
 \ITA{\ITAph{Alcune basi teoriche}}
 \PTBR{\PTBRph{}}


### PR DESCRIPTION
When compiling the book, an empty German headline is printed. this fixes the issue