### PR TITLE
Fix typo in the footnote and 3 verbs ending with "s"

### DIFF
--- a/advanced/102_fib/main_EN.tex
+++ b/advanced/102_fib/main_EN.tex
@@ -36,7 +36,7 @@ Let's load the example in \olly and trace to the last call of \ttf{}:
 Let's investigate the stack more closely. 
 Comments were added by the author of this book
 \footnote{By the way, it's possible to select several entries in \olly and copy them to the clipboard (Ctrl-C).
-That's what was done my author for this example.}:
+That's what was done by author for this example.}:
 
 \lstinputlisting{\CURPATH/stack_EN.txt}
 

--- a/advanced/111_netmask/main_EN.tex
+++ b/advanced/111_netmask/main_EN.tex
@@ -104,7 +104,7 @@ And this is how it's done by non-optimizing MSVC 2012:
 
 \lstinputlisting[caption=\NonOptimizing MSVC 2012]{\CURPATH/form_IP_MSVC_2012_EN.asm}
 
-Well, the order is different, but, of course, the order of the operations doesn't matters.
+Well, the order is different, but, of course, the order of the operations doesn't matter.
 
 \Optimizing MSVC 2012 does essentially the same, but in a different way:
 

--- a/patterns/07_jcc/simple/ARM/ARM32_EN.tex
+++ b/patterns/07_jcc/simple/ARM/ARM32_EN.tex
@@ -55,7 +55,7 @@ The \TT{LDMGEFD SP!, \{R4-R6,PC\}} instruction acts like a function epilogue, bu
 \myindex{Function epilogue}
 
 But if that condition is not satisfied, i.e., $a<b$, then the control flow will continue to the next \\
-\TT{\q{LDMFD SP!, \{R4-R6,LR\}}} instruction, which is one more function epilogue. This instruction restores not only the \TT{R4-R6} registers state, but also \ac{LR} instead of \ac{PC}, thus, it does not returns from the function.
+\TT{\q{LDMFD SP!, \{R4-R6,LR\}}} instruction, which is one more function epilogue. This instruction restores not only the \TT{R4-R6} registers state, but also \ac{LR} instead of \ac{PC}, thus, it does not return from the function.
 The last two instructions call \printf with the string <<a<b\textbackslash{}n>> as a sole argument.
 We already examined an unconditional jump to the \printf function instead of function return in <<\PrintfSeveralArgumentsSectionName>> section~(\myref{ARM_B_to_printf}).
 

--- a/patterns/13_arrays/1_simple/MIPS_EN.tex
+++ b/patterns/13_arrays/1_simple/MIPS_EN.tex
@@ -6,7 +6,7 @@ values are saved in the function prologue and restored in the epilogue.
 
 \lstinputlisting[caption=\Optimizing GCC 4.4.5 (IDA)]{patterns/13_arrays/1_simple/MIPS_O3_IDA_EN.lst}
 
-Something interesting: there are two loops and the first one doesn't needs $i$, it needs only 
+Something interesting: there are two loops and the first one doesn't need $i$, it needs only 
 $i*2$ (increased by 2 at each iteration) and also the address in memory (increased by 4 at each iteration).
 
 So here we see two variables, one (in \$V0) increasing by 2 each time, and another (in \$V1) --- by 4.


### PR DESCRIPTION
grep helped me to find 3 verbs preceded by "does not" or
"doesn't" and ending with "s".