### PR TITLE
examples: rename the example chapter

### DIFF
--- a/examples/examples.tex
+++ b/examples/examples.tex
@@ -1,4 +1,5 @@
-\chapter{\RU{Примеры из практики}\EN{Examples from practice}}
+\chapter{\RU{Примеры из практики}\EN{Examples for practice}}
+% Could we name it 'case studies' or 'examples for practice' for english? - 'Examples from practice' seems a little vague.
 
 %\clearpage
 \begin{center}


### PR DESCRIPTION
Rename the example chapter in english from Examples from practice to
'Examples from practice'. Also suggest a new name 'Case Studies', which
looks a little neat.