### PR TITLE
French: typo/update in numeral_FR

### DIFF
--- a/advanced/100_fahrenheit/main_FR.tex
+++ b/advanced/100_fahrenheit/main_FR.tex
@@ -1,4 +1,4 @@
-\section{Conversion de témpérature}
+\section{Conversion de température}
 
 Un autre exemple très populaire dans
 les livres de programmation est un petit programme qui convertit une température de Fahrenheit vers Celsius ou inversemment.
@@ -9,7 +9,7 @@ les livres de programmation est un petit programme qui convertit une températur
 
 Nous pouvons aussi ajouter une gestion des erreurs simples:
 1) nous devons vérifier si l'utilisateur a entré un nombre correct;
-2) nous devons tester si la température en Ceslius n'est pas en dessous de $-273$ 
+2) nous devons tester si la température en Celsius n'est pas en dessous de $-273$ 
 (qui est en dessous du zéro absolu, comme vu pendant les cours de physique à l'école)
 
 \myindex{\CStandardLibrary!exit()}
@@ -30,9 +30,9 @@ Ce que l'on peut en dire:
 \item L'adresse de \printf est d'abord chargé dans le
 registre \ESI, donc les futurs
 appels \printf sont faits juste par l'instruction \TT{CALL ESI}.
-C'est une technique très populaireIt's a very popular compiler 
+C'est une technique très populaire
 des compilateurs, possible si plusieurs appels consécutifs vers la même fonction sont sont présents
-dans le code, et/ou s'il y a un registre disponible qui peut être utilisé pour ca.
+dans le code, et/ou s'il y a un registre disponible qui peut être utilisé pour ça.
 
 \item Nous voyons l'instruction \TT{ADD EAX, -32} 
 à l'endroit où 32 doit être soustrait de la valeur.
@@ -45,11 +45,11 @@ Peut-être que ca vaut la peine, difficile d'en être sûr.
 la valeur est multipliée par 5: \TT{lea ecx, DWORD PTR [eax+eax*4]}.
 Oui, $i+i*4$ équivaut à $i*5$ et \LEA 
 marche plus rapidement que \TT{IMUL}.\\
-D'ailleurs, la paire d'instructions \TT{SHL EAX, 2 / ADD EAX, EAX} peut aussi être utilisée içi---
+D'ailleurs, la paire d'instructions \TT{SHL EAX, 2 / ADD EAX, EAX} peut aussi être utilisée ici---
 certains compilateur le font.
 
 \item La division par l'astuce de la multiplication (\myref{sec:divisionbymult}) 
-est aussi utilisée içi.
+est aussi utilisée ici.
 
 \item \main retourne 0 si nous n'avons pas \TT{return 0} 
 à la fin.
@@ -63,7 +63,7 @@ Cependant, MSVC ne supporte pas officiellement C99, mais peut-être qu'il le sup
 
 \subsubsection{\Optimizing MSVC 2012 x64}
 
-Le code est quasiment le même, mais nous pouvons trouver les instructions \TT{INT 3} après chaque appel \TT{exit()}.
+Le code est quasiment le même, mais nous pouvons trouver les instructions \TT{INT 3} après chaque appel à \TT{exit()}.
 
 \begin{lstlisting}[style=customasmx86]
 	xor	ecx, ecx
@@ -75,7 +75,7 @@ Le code est quasiment le même, mais nous pouvons trouver les instructions \TT{I
 
 C'est connu que \TT{exit()} est l'une des fonctions qui ne retourne jamais
 \footnote{une autre populaire est \TT{longjmp()}},
-donc s'il elle le fait, quelque chose de vraiment étrange est arrivé et il est temps de lancer le debugger.
+donc si elle le fait, quelque chose de vraiment étrange est arrivé et il est temps de lancer le debugger.
 
 \subsection{Floating-point values}
 

--- a/patterns/01_helloworld/address_patching_FR.tex
+++ b/patterns/01_helloworld/address_patching_FR.tex
@@ -1,0 +1,73 @@
+\subsubsection{Modification d'adresse (Win64)}
+
+Lorsque notre exemple est compilé sous MSVC2013 avec l'option \TT{\textbackslash{}MD}
+(générant un exécutable plus petit à cause du lien avec \TT{MSVCR*.DLL}), la fonction \main vient en premier et
+est trouvée facilement:
+
+\begin{figure}[H]
+\centering
+\myincludegraphics{patterns/01_helloworld/hiew_incr1.png}
+\caption{Hiew}
+\label{}
+\end{figure}
+
+A titre expérimental, nous pouvons \gls{incrémenter} l'adresse du pointeur de 1:
+
+\begin{figure}[H]
+\centering
+\myincludegraphics{patterns/01_helloworld/hiew_incr2.png}
+\caption{Hiew}
+\label{}
+\end{figure}
+
+Hiew montre la chaîne \q{ello, world}.
+Et lorsque nous lançons l'exécutable modifié, la chaîne raccourcie est affichée.
+
+\subsubsection{Utiliser une autre chaîne d'un binaire (Linux x64)}
+
+Le fichier binaire que j'obtiens en compilant notre exemple avec GCC 5.4.0 sur un système Linux x64 contient de
+nombreuses autres chaînes:
+la plupart sont des noms de fonction et de bibliotèque importées.
+
+Je lance \IT{objdump} pour voir le contenu de toutes les sections du fichier compilé:
+
+\begin{lstlisting}[basicstyle=\ttfamily, mathescape]
+$\$$ objdump -s a.out
+
+a.out:     file format elf64-x86-64
+
+Contents of section .interp:
+ 400238 2f6c6962 36342f6c 642d6c69 6e75782d  /lib64/ld-linux-
+ 400248 7838362d 36342e73 6f2e3200           x86-64.so.2.
+Contents of section .note.ABI-tag:
+ 400254 04000000 10000000 01000000 474e5500  ............GNU.
+ 400264 00000000 02000000 06000000 20000000  ............ ...
+Contents of section .note.gnu.build-id:
+ 400274 04000000 14000000 03000000 474e5500  ............GNU.
+ 400284 fe461178 5bb710b4 bbf2aca8 5ec1ec10  .F.x[.......^...
+ 400294 cf3f7ae4                             .?z.
+
+...
+\end{lstlisting}
+
+Ce n'est pas un problème de passer l'adresse de la chaîne \q{/lib64/ld-linux-x86-64.so.2} à l'appel de \TT{printf()}:
+
+\begin{lstlisting}[style=customc]
+#include <stdio.h>
+
+int main()
+{
+    printf(0x400238);
+    return 0;
+}
+\end{lstlisting}
+
+Difficile à croire, ce code affiche la chaîne mentionnée.
+
+%%On your system, executable may be slightly different, and all addresses will also be different.
+%%Also, adding/removing code to/from this source code will probably shift all addresses back and forth.
+Changez l'adresse en \TT{0x400260}, et la chaîne \q{GNU} sera affichée.
+L'adresse est valable pour cette version spécifique de GCC, outils GNU, etc.
+Sur votre système, l'exécutable peut être légèrement différent, et toutes les adresses seront différentes.
+Ainsi, ajouter/supprimer du code à/de ce code source va probablement décaler les adresses en arrière et avant.
+

--- a/patterns/01_helloworld/main_FR.tex
+++ b/patterns/01_helloworld/main_FR.tex
@@ -1,0 +1,33 @@
+\section{\HelloWorldSectionName}
+\label{sec:helloworld}
+
+Utilisons le fameux exemple du livre \KRBook:
+
+\lstinputlisting[style=customc]{patterns/01_helloworld/hw.c}
+
+\subsection{x86}
+
+\input{patterns/01_helloworld/MSVC_x86}
+\input{patterns/01_helloworld/GCC_x86}
+\input{patterns/01_helloworld/string_patching_FR}
+
+\subsection{x86-64}
+\input{patterns/01_helloworld/MSVC_x64}
+\input{patterns/01_helloworld/GCC_x64}
+\input{patterns/01_helloworld/address_patching_FR}
+
+\input{patterns/01_helloworld/GCC_one_more}
+\input{patterns/01_helloworld/ARM/main}
+\input{patterns/01_helloworld/MIPS/main}
+
+\subsection{\Conclusion{}}
+
+La différence principale entre le code x86/ARM et x64/ARM64 est que le pointeur sur la chaîne a une taille de 64 bits.
+Le fait est que les \ac{CPU}s modernes sont maintenant 64-bit à cause le la baisse du coût de la mémoire et du grand
+besoin de cette dernière par les applications modernes.
+Nous pouvons ajouter bien plus de mémoire à nos ordinateurs que les pointeurs 32-bit ne peuvent en adresser.
+Ainsi, tous les pointeurs sont maintenant 64-bit.
+
+% sections
+\input{patterns/01_helloworld/exercises}
+

--- a/patterns/01_helloworld/string_patching_FR.tex
+++ b/patterns/01_helloworld/string_patching_FR.tex
@@ -1,0 +1,58 @@
+\subsubsection{Modification de chaînes (Win32)}
+
+Nous pouvons facilement trouver la chaîne ``hello, world'' dans l'exécutable en utilisant Hiew:
+
+\begin{figure}[H]
+\centering
+\myincludegraphics{patterns/01_helloworld/hola_edit1.png}
+\caption{Hiew}
+\label{}
+\end{figure}
+
+Et nous pouvons essayer de traduire notre message en espagnol:
+
+\begin{figure}[H]
+\centering
+\myincludegraphics{patterns/01_helloworld/hola_edit2.png}
+\caption{Hiew}
+\label{}
+\end{figure}
+
+Le texte en espagnol est un octet plus court que celui en anglais, nous ajoutons l'octet 0x0A à la fin
+ (\TT{\textbackslash{}n}) ainsi qu'un octet à zéro.
+
+Ca fonctionne.
+
+Comment faire si nous voulons insèrer un message plus long ?
+Il y a quelques octets à zéro après le texte original en anglais.
+Il est difficile de dire si ils peuvent être écrasés: ils peuvent être utilisés quelque part dans du code \ac{CRT},
+ou pas.
+De toutes façons, écrasez-les seulement si vous savez vraiment ce que vous faîtes.
+
+\subsubsection{Modification de chaînes (Linux x64)}
+
+\myindex{\radare}
+Essayons de modifier un exécutable Linux x64 en utilisant \radare:
+
+\lstinputlisting[caption=\radare{} session]{patterns/01_helloworld/radare.lst}
+
+Ce que je fais ici: je cherche la chaîne \q{hello} en utilisant la commande  \TT{/},
+ensuite je déplace le \IT{curseur} (ou \IT{seek} selon la terminologie de \radare) à cette adresse.
+Je veux être certain d'être à la bonne adresse: \TT{px} affiche les octets ici.
+\TT{oo+} passe \radare en mode \IT{read-write}.
+\TT{w} écrit une chaîne ASCII à la \IT{seek} (\IT{position}) courante.
+Notez le \TT{\textbackslash{}00} à la fin--c'est l'octet à zéro.
+\TT{q} quitte.
+
+\subsubsection{\IT{Traduction} de logiciel à l'ère MS-DOS}
+
+%%The way I described was a common way to translate MS-DOS software to Russian language back to 1980's and 1990's.
+%%Russian words and sentences are usually slightly longer than its English counterparts, so that is why \IT{localized}
+%%software has a lot of weird acronyms and hardly readable abbreviations.
+La méthode que je viens de décrire était couramment employée pour traduire des logiciels sous MS-DOS en russe dans les
+années 1980 et 1990.
+Les mots et les phrases russes sont en général un peu plus longs qu'en anglais, c'est pourquoi les logiciels
+\IT{traduits} sont pleins d'acronymes sybillins et d'abréviations difficilement lisibles.
+
+Peut-être que cela s'est produit pour d'autres langages durant cette période.
+

--- a/patterns/numeral_FR.tex
+++ b/patterns/numeral_FR.tex
@@ -10,12 +10,13 @@ Si le système de numération a 10 chiffres, il est en \IT{base} 10. % \IT{radix
 Le système binaire est en \IT{base} 2.
 
 Rappels importants :
-1) Un \IT{nombre} est un nombre, tandis qu'un \IT{chiffre} est un moyen d'écriture et est généralement un caractère;
-2) Un nombre ne change pas lorsqu'on le convertit dans une autre base : sa notation change.
+1) Un \IT{nombre} est un nombre, tandis qu'un \IT{chiffre} est un élément d'un système d'écriture et est généralement un caractère;
+2) Un nombre ne change pas lorsqu'on le convertit dans une autre base : sa représentation change.
 
 Comment convertir un nombre d'un base à une autre ?
 
-La notation positionnelle est utilisée quasiment partout, cela signifie qu'un chiffre (nombre contenu dans un seul caractère) a un certain poids dépendant de sa position.
+La notation positionnelle est utilisée quasiment partout, cela signifie qu'un chiffre (nombre contenu dans un seul caractère) a
+ un poids dépendant de sa position dans la représentation du nombre.
 Si 2 se situe le plus à droite, c'est 2.
 S'il est placé un chiffre avant celui le plus à droite, c'est 20.
 
@@ -30,14 +31,14 @@ Que représente 0b101011 ?
 $2^5 \cdot 1 + 2^4 \cdot 0 + 2^3 \cdot 1 + 2^2 \cdot 0 + 2^1 \cdot 1 + 2^0 \cdot 1 = 43$ ou
 $32 \cdot 1 + 16 \cdot 0 + 8 \cdot 1 + 4 \cdot 0 + 2 \cdot 1 + 1 = 43$
 
-On peut opposer la notation positionnelle avec la notation non-positionnelle comme la numération romaine
+On peut opposer la notation positionnelle avec la notation non-positionnelle comme la numération romaine.
 \footnote{A propos de l'évolution du système de numération, voir \InSqBrackets{\TAOCPvolII{}, 195--213.}}.
-Peut-être que l'Humanité a choisi le système de numération positionnelle parce qu'il était plus simple pour les opérations basiques (addition, multiplication, etc.) à la main sur papier.
+Peut-être que l'humanité a choisi le système de numération positionnelle parce qu'il était plus simple pour les opérations basiques (addition, multiplication, etc.) à la main sur papier.
 
 En effet, les nombres binaires peuvent être ajoutés, soustraits et ainsi de suite de la même manière que c'est enseigné à l'école, mais seulement 2 chiffres sont disponibles.
 
 Les nombres binaires sont volumineux pour représenter le code source et les dumps, c'est pourquoi le système hexadécimal peut etre utilisé.
-Les nombres en base hexadécimal utilisent les nombres 0..9 et aussi 6 caractères latins : A..F.
+La base hexadécimale utilise les nombres 0..9 et aussi 6 caractères latins : A..F.
 Chaque chiffre hexadécimal prend 4 bits ou 4 chiffres binaires, donc c'est très simple de convertir un nombre binaire vers l'hexadécimal et inversement, même manuellement.
 
 \begin{center}
@@ -67,14 +68,14 @@ F	&1111	&15 \\
 
 Comment savoir quelle est la base actuellement utilisée ?
 
-Les nombres décimaux sont d'ordinaire écrits tels quels, i.e, 1234. Mais certains assembleurs autorisent d'accentuer la base décimale d'un nombre et ce nombre peut s'écrire avec un "d" en suffixe : 1234d.
+Les nombres décimaux sont d'ordinaire écrits tels quels, i.e, 1234. Mais certains assembleurs permettent d'accentuer la base décimale, et les nombres peuvent alors s'écrire avec le suffixe "d" : 1234d.
 
-Les nombres binaires sont parfois écrits avec le préfixe "0b" : 0b100110111 (\ac{GCC} a une extension de langage non-standard pour ca \footnote{\url{https://gcc.gnu.org/onlinedocs/gcc/Binary-constants.html})}.
+Les nombres binaires sont parfois préfixés avec "0b" : 0b100110111 (\ac{GCC} a une extension de langage non-standard pour ca \footnote{\url{https://gcc.gnu.org/onlinedocs/gcc/Binary-constants.html})}.
 Il y a aussi un autre moyen : le suffixe "b", par exemple : 100110111b.
 J'essaierai de garder le préfixe "0b" tout le long du livre pour les nombres binaires.
 
-Les nombres hexadécimaux sont écrits avec le préfixe "0x" en \CCpp et autres \ac{PL}s : 0x1234ABCD.
-Ou il y a le suffixe "h" : 1234ABCDh - c'est une manière commune de les représenter dans les assembleurs et les débuggeurs.
+Les nombres hexadécimaux sont préfixés avec "0x" en \CCpp et autres \ac{PL}s : 0x1234ABCD.
+Ou ils ont le suffixe "h" : 1234ABCDh - c'est une manière commune de les représenter dans les assembleurs et les débuggeurs.
 Si le nombre commence par un A..F, un 0 est ajouté au début : 0ABCDEFh.
 J'essaierai de garder le préfixe "0x" tout le long du livre pour les nombres hexadécimaux.
 
@@ -87,7 +88,7 @@ Il est maintenant remplacé par le système hexadécimal quasiment partout mais,
 
 \myindex{UNIX!chmod}
 Comme beaucoup d'utilisateur *NIX le savent, l'argument de \TT{chmod} peut être un nombre à 3 chiffres. Le premier correspond aux droits du propriétaire du fichier, le scond correspond aux droits pour le groupe (auquel le fichier appartient), le troisième est pour tous les autres.
-Et chaque caratère peut être représenté en binaire:
+Et chaque chiffre peut être représenté en binaire:
 
 \begin{center}
 \begin{longtable}{ | l | l | l | }
@@ -107,11 +108,11 @@ Et chaque caratère peut être représenté en binaire:
 \end{longtable}
 \end{center}
 
-Ainsi chaque bit correspond à un flag: lecture (r) / écriture (w) / exécution (x).
+Ainsi chaque bit correspond à un droit: lecture (r) / écriture (w) / exécution (x).
 
-La raison pour laquelle je parle de \TT{chmod} ici est que le nombre passé en argument peut être écrit comme un nombre octal.
+La raison pour laquelle je parle de \TT{chmod} ici est que l'argument peut être écrit comme un nombre octal.
 Prenons par exemple, 644.
-Quand vous tapez \TT{chmod 644 file}, vous définissez les permissions de lecture/écriture pour le propriétaire, les permissions de lecture pour le groupe et encore les permissions de lecture pour les autres.
+Quand vous tapez \TT{chmod 644 file}, vous définissez les droits de lecture/écriture pour le propriétaire, les droits de lecture pour le groupe et encore les droits de lecture pour les autres.
 Convertissons le nombre 644 en octal vers le binaire, ce sera \TT{110100100}, ou (par groupe de 3 bits) \TT{110 100 100}.
 
 Maintenant que nous savons que chaque triplet sert a décrire les permissions pour le propriétaire/groupe/autres : le premier est \TT{rw-}, le second est \TT{r--} et le troisième est \TT{r--}.
@@ -123,29 +124,32 @@ Le système de numération octal est supporté par tous les compilateurs \CCpp s
 C'est parfois une source de confusion parce que les nombres octaux sont notés avec un zéro au début. Par exemple, 0377 est 255.
 Et parfois, vous faites une faute de frappe et écrivez "09" au lieu de 9, et le compilateur ne vous l'autorise pas.
 GCC peut renvoyer quelque chose comme ca:\\
-\TT{error: invalid digit "9" in octal constant}. % TODO : translate this too ?
+\TT{erreur: chiffre  9  invalide dans la constante en base 8}.
 
 \subsubsection{Divisibilité}
 
-Quand vous voyez un nombre décimal comme 120, vous pouvez rapidement déduire qu'il est divisible par 10, parce que le dernier chiffre est zéro.
+Quand vous voyez un nombre décimal comme 120, vous en déduisez immédiatement qu'il est divisible par 10, parce que le dernier chiffre est zéro.
 Egalement, 123400 est divisible par 100 parce que les deux derniers chiffres sont zéros.
 
 De la même façon, un nombre hexadécimal 0x1230 est divisible par 0x10 (ou 16), 0x123000 est disible par 0x1000 (ou 4096), etc.
 
 Un nombre binaire 0b1000101000 est divisible par 0b1000 (8), etc.
 
-Cette propriété peut être souvent utilisée pour déterminer rapidement si la taille d'un bloc mémoire correspond à la limite.
+Cette propriété peut être souvent utilisée pour déterminer rapidement si la taille d'un bloc mémoire correspond à la limite. % TODO clarify original
 Par exemple, les sections dans les fichiers \ac{PE} commencent quasiment toujours à une adresse finissant par 3 zéros hexadécimaux: 0x41000, 0x10001000, etc.
-La raison derrière ce fait est que la plupart des sections \ac{PE} sont remplies à la limite de 0x1000 (4096) octets.
+La raison sous-jacente est que la plupart des sections \ac{PE} sont alignées sur une limite de 0x1000 (4096) octets.
 
 \subsubsection{Arithmétique multiprécision et base}
 
 \index{RSA}
-L'arithmétique multiprécision utilise des nombres très grands et peuvent chacun être enregistré sur plusieurs octets.
-Par exemple, les clés RSA utilisent jusqu'à 4096 bits et parfois plus encore.
+L'arithmétique multiprécision utilise des nombres très grands et chacun peut être stocké sur plusieurs octets.
+Par exemple, les clés RSA, tant publique que privée, utilisent jusqu'à 4096 bits et parfois plus encore.
 
-Dans \InSqBrackets{\TAOCPvolII, 265} vous pouvez trouver l'idée suivante: quand vous enregistrez un nombre multiprécision dans plusieurs octets. Tout le nombre peut être représenté avec une base de $2^8=256$, et chaque chiffre est associé à l'octet correspondant.
-De la même manière, si vous sauvegardez un nombre multiprécision sur plusieurs entiers de 32 bits, chaque chiffre est associé à l'emplacement de 32 bits et vous pouvez penser que ce nombre est stocké dans une base $2^{32}$.
+Dans \InSqBrackets{\TAOCPvolII, 265} vous pouvez trouver l'idée suivante: quand vous stockez un nombre multiprécision
+dans plusieurs octets.
+Le nombre complet peut être représenté dans une base de $2^8=256$, et chacun des chiffres correspond à un octet.
+De la même manière, si vous sauvegardez un nombre multiprécision sur plusieurs entiers de 32 bits, chaque chiffre est associé
+ à l'emplacement de 32 bits et vous pouvez penser à ce nombre comme étant stocker dans une base $2^{32}$.
 
 \subsubsection{Prononciation}
 


### PR DESCRIPTION
Used GCC translated error message.
Some stuff still need to be clarified/discussed.