### PR TITLE
Typo

### DIFF
--- a/patterns/01_helloworld/ARM/ARM64_EN.tex
+++ b/patterns/01_helloworld/ARM/ARM64_EN.tex
@@ -12,7 +12,7 @@ The Register count is doubled: \myref{ARM64_GPRs}.
 
 \myindex{ARM!\Instructions!STP}
 The \TT{STP} instruction (\IT{Store Pair}) 
-saves two registers in the stack simultaneously: \RegX{29} in \RegX{30}.
+saves two registers in the stack simultaneously: \RegX{29} and \RegX{30}.
 
 Of course, this instruction is able to save this pair at an arbitrary place in memory, 
 but the \ac{SP} register is specified here, so the pair is saved in the stack.
@@ -88,7 +88,7 @@ The result is the same, but that's how \MOV at that line looks like now:
 
 \INS{LDP} (\IT{Load Pair}) then restores the \RegX{29} and \RegX{30} registers.
 
-There is no exclamation mark after the instruction: this implies that the value is first loaded from the stack,
+There is no exclamation mark after the instruction: this implies that the values are first loaded from the stack,
 and only then is \ac{SP} increased by 16.
 This is called \IT{post-index}.
 


### PR DESCRIPTION
As we're handling 2 registers, plural sounds okay.
I translated like this in French.