### PR TITLE
Typo: missing \ for CALL

### DIFF
--- a/patterns/02_stack/01_saving_ret_addr_EN.tex
+++ b/patterns/02_stack/01_saving_ret_addr_EN.tex
@@ -4,7 +4,7 @@
 
 \myindex{x86!\Instructions!CALL}
 When calling another function with a \CALL instruction, the address of the point exactly after the \CALL instruction is saved 
-to the stack and then an unconditional jump to the address in the CALL operand is executed.
+to the stack and then an unconditional jump to the address in the \CALL operand is executed.
 
 \myindex{x86!\Instructions!PUSH}
 \myindex{x86!\Instructions!JMP}

--- a/patterns/02_stack/01_saving_ret_addr_ITA.tex
+++ b/patterns/02_stack/01_saving_ret_addr_ITA.tex
@@ -4,7 +4,7 @@
 
 \myindex{x86!\Instructions!CALL}
 Quando si chiama una funzione con l'istruzione \CALL, l'indirizzo del punto esattamente dopo la \CALL viene salvato nello stack, e successivamente
-viene eseguito un jump non condizionale all'indirizzo dell'operando di CALL.
+viene eseguito un jump non condizionale all'indirizzo dell'operando di \CALL.
 
 \myindex{x86!\Instructions!PUSH}
 \myindex{x86!\Instructions!JMP}

--- a/patterns/02_stack/01_saving_ret_addr_PTBR.tex
+++ b/patterns/02_stack/01_saving_ret_addr_PTBR.tex
@@ -4,7 +4,7 @@
 
 \myindex{x86!\Instructions!CALL}
 Quando você chama outra função utilizando a instrução CALL, o endereço do ponto exato onde a 
-instrução \CALL se encontra é salvo na pilha e então um jump incondicional para o endereço no operando de CALL é executado.
+instrução \CALL se encontra é salvo na pilha e então um jump incondicional para o endereço no operando de \CALL é executado.
 
 \myindex{x86!\Instructions!PUSH}
 \myindex{x86!\Instructions!JMP}


### PR DESCRIPTION
Quite sure \ is missing.