### PR TITLE
German: typos

### DIFF
--- a/patterns/02_stack/01_saving_ret_addr_DE.tex
+++ b/patterns/02_stack/01_saving_ret_addr_DE.tex
@@ -81,7 +81,7 @@ GCC 4.4.1 generiert vergleichbaren Code in beiden Fällen, jedoch ohne über das
 
 ARM Programme benutzen den Stack um Rücksprung Adressen zu speichern, aber anders.
 Wie bereits erwähnt in \q{\HelloWorldSectionName}~(\myref{sec:hw_ARM}),
-wird der \ac{RA} Wert im im \ac{LR} (\gls{link register}) in seiner binärer Form gespeichert.
+wird der \ac{RA} Wert im \ac{LR} (\gls{link register}) gespeichert.
 Wenn nun eine andere Funktion aufgerufen werden muss und auf das \ac{LR} Register 
 zu greift, muss der aktuelle Wert im Register irgendwo gespeichert werden.
 


### PR DESCRIPTION
Double "im"
Correction according https://github.com/dennis714/RE-for-beginners/commit/ee800942c988940b72b5d18350841c25a8db5863