### PR TITLE
01_saving_ret_addr: stack overflow index

### DIFF
--- a/macros.tex
+++ b/macros.tex
@@ -697,6 +697,7 @@
 % ML prefix is for multi-lingual words and sentences:
 \newcommand{\MLHeap}{\EN{Heap}\RU{Куча}\PTBR{Heap}\FR{Heap}}
 \newcommand{\MLStack}{\EN{Stack}\RU{Стэк}\PTBR{Pilha}\FR{Pile}}
+\newcommand{\MLStackOverflow}{\EN{Stack overflow}\RU{Переполнение стека}\PTBR{\TBT}\FR{Débordement de pile}\DE{\TBT}\ITA{\TBT}}
 \newcommand{\MLStartOfHeap}{\RU{Начало кучи}\EN{Start of heap}\PTBR{começo da heap}\FR{Début du heap}}
 \newcommand{\MLStartOfStack}{\RU{Вершина стека}\EN{Start of stack}\PTBR{começo da pilha}\FR{Début de la pile}}
 \newcommand{\MLinputA}{\RU{вход А}\EN{input A}\FR{entrée A}}

--- a/patterns/02_stack/01_saving_ret_addr_DE.tex
+++ b/patterns/02_stack/01_saving_ret_addr_DE.tex
@@ -15,7 +15,7 @@ Die \CALL Instruktion ist äquivalent zu dem \INS{PUSH address\_after\_call / JM
 \RET ruft die Rückkehr Adresse vom Stack ab und springt zu dieser~---was äquivalent zu einem \TT{POP tmp / JMP tmp} Instruktions
 paar ist.
 
-\myindex{\Stack!\RU{Переполнение стека}\EN{Stack overflow}\PTBRph{}}
+\myindex{\Stack!\MLStackOverflow}
 \myindex{\Recursion}
 
 Den Stack zum überlaufen zu bringen ist recht einfach, einfach eine 

--- a/patterns/02_stack/01_saving_ret_addr_EN.tex
+++ b/patterns/02_stack/01_saving_ret_addr_EN.tex
@@ -15,7 +15,7 @@ The \CALL instruction is equivalent to a\\
 \myindex{x86!\Instructions!POP}
 \RET fetches a value from the stack and jumps to it~---that is equivalent to a \TT{POP tmp / JMP tmp} instruction pair.
 
-\myindex{\Stack!\RU{Переполнение стека}\EN{Stack overflow}\PTBRph{}}
+\myindex{\Stack!\MLStackOverflow}
 \myindex{\Recursion}
 Overflowing the stack is straightforward. Just run eternal recursion:
 

--- a/patterns/02_stack/01_saving_ret_addr_FR.tex
+++ b/patterns/02_stack/01_saving_ret_addr_FR.tex
@@ -17,7 +17,7 @@ paire d'instructions \INS{PUSH address\_after\_call / JMP operand}.
 \RET va chercher une valeur sur la pile et y saute~---ce qui est équivalent à
 la paire d'instructions \TT{POP tmp / JMP tmp}.
 
-\myindex{\Stack!\FR{Débordement de pile}}
+\myindex{\Stack!\MLStackOverflow}
 \myindex{\Recursion}
 Déborder de la pile est très facile. Il suffit de lancer une récursion éternelle:
 

--- a/patterns/02_stack/01_saving_ret_addr_ITA.tex
+++ b/patterns/02_stack/01_saving_ret_addr_ITA.tex
@@ -14,7 +14,7 @@ L'istruzione \CALL e' equivalente alla coppia di istruzioni \INS{PUSH indirizzo\
 \myindex{x86!\Instructions!POP}
 \RET preleva un valore dallo stack e effettua un jump ad esso~--- cio' equivale alla coppia di istruzioni \TT{POP tmp / JMP tmp}.
 
-\myindex{\Stack!\RU{Переполнение стека}\EN{Stack overflow}\PTBRph{}}
+\myindex{\Stack!\MLStackOverflow}
 \myindex{\Recursion}
 
 Riempire lo stack fino allo straripamento e' semplicissimo. Basta ricorrere alla ricorsione eterna:

--- a/patterns/02_stack/01_saving_ret_addr_PTBR.tex
+++ b/patterns/02_stack/01_saving_ret_addr_PTBR.tex
@@ -14,7 +14,7 @@ A instrução \CALL é equivalente a usar o par de instruções \TT{PUSH endere�
 \myindex{x86!\Instructions!POP}
 \RET pega um valor da pilha e usa um jump para ele --- isso é equivalente a usar \INS{POP tmp / JMP tmp}.
 
-\myindex{\Stack!\RU{Переполнение стека}\EN{Stack overflow}\PTBRph{}}
+\myindex{\Stack!\MLStackOverflow}
 \myindex{\Recursion}
 Estourar uma stack é fácil. Só execute alguma recursão externa:
 

--- a/patterns/02_stack/01_saving_ret_addr_RU.tex
+++ b/patterns/02_stack/01_saving_ret_addr_RU.tex
@@ -15,7 +15,7 @@
 \RET вытаскивает из стека значение и передает управление по этому адресу~--- 
 это аналог пары инструкций \TT{POP tmp / JMP tmp}.
 
-\myindex{\Stack!\RU{Переполнение стека}\EN{Stack overflow}\PTBRph{}}
+\myindex{\Stack!\MLStackOverflow}
 \myindex{\Recursion}
 Крайне легко устроить переполнение стека, запустив бесконечную рекурсию:
 


### PR DESCRIPTION
Handle the index text with a macro.
Remove language dependant code from language file (ex: \EN{} will never do something in a _FR file)
I think it's a remaining from first version, with one file for all languages.