### PR TITLE
French: escapings in listings, minor translation

### DIFF
--- a/patterns/01_helloworld/MIPS/hw_O0_FR.s
+++ b/patterns/01_helloworld/MIPS/hw_O0_FR.s
@@ -6,7 +6,7 @@ main:
 	addiu	$sp,$sp,-32
 	sw	$31,28($sp)
 	sw	$fp,24($sp)
-; §définir FP§ (stack frame pointer):
+; §définir le pointeur de pile FP§ (stack frame pointer):
 	move	$fp,$sp
 ; §définir GP:§
 	lui	$28,%hi(__gnu_local_gp)
@@ -24,7 +24,7 @@ main:
 
 ; restaurer GP depuis la pile locale:
 	lw	$28,16($fp)
-; §mettre le registre $2 ($V0) à zéro:§
+; §mettre le registre \$2 (\$V0) à zéro:§
 	move	$2,$0
 ; §épilogue de la fonction.§
 ; restaurer SP:
@@ -36,4 +36,4 @@ main:
 	addiu	$sp,$sp,32
 ; sauter en RA:
 	j	$31
-	nop  ; slot de retard de branchement
+	nop  ; §slot de délai de branchement§

--- a/patterns/01_helloworld/MIPS/hw_O0_IDA_FR.lst
+++ b/patterns/01_helloworld/MIPS/hw_O0_IDA_FR.lst
@@ -26,7 +26,7 @@
 .text:00000034                 or      $at, $zero ; NOP
 ; restaurer GP depuis la pile locale:
 .text:00000038                 lw      $gp, 0x20+var_10($fp)
-; §mettre le registre $2 ($V0) à zéro:§
+; §mettre le registre \$2 (\$V0) à zéro:§
 .text:0000003C                 move    $v0, $zero
 ; §épilogue de la fonction.§
 ; restaurer SP:

--- a/patterns/01_helloworld/MIPS/hw_O3_FR.s
+++ b/patterns/01_helloworld/MIPS/hw_O3_FR.s
@@ -11,7 +11,7 @@ main:
 	sw	$31,28($sp)
 ; charger l'adresse de la fonction puts() dans $25 depuis GP:
 	lw	$25,%call16(puts)($28)
-; §charger ladresse de la chaîne de texte dans $4 ($a0):§
+; §charger l'adresse de la chaîne de texte dans \$4 (\$a0):§
 	lui	$4,%hi($LC0)
 ; §sauter à puts(), en sauvant l'adresse de retour dans le register link:§
 	jalr	$25

--- a/patterns/01_helloworld/MIPS/hw_O3_IDA_FR.lst
+++ b/patterns/01_helloworld/MIPS/hw_O3_IDA_FR.lst
@@ -15,7 +15,7 @@
 .text:00000010                 sw      $gp, 0x20+var_10($sp)
 ; charger l'adresse de la fonction puts() dans $9 depuis GP:
 .text:00000014                 lw      $t9, (puts & 0xFFFF)($gp)
-; form the address of the text string in $a0:
+; §générer l'adresse de la chaîne de texte dans \$a0:§
 .text:00000018                 lui     $a0, ($LC0 >> 16)  # "Hello, world!"
 ; §sauter à puts(), en sauvant l'adresse de retour dans le register link:§
 .text:0000001C                 jalr    $t9

--- a/patterns/03_printf/MIPS/printf3.O0_FR.s
+++ b/patterns/03_printf/MIPS/printf3.O0_FR.s
@@ -27,7 +27,7 @@ main:
 	jalr	$25
 	nop
 
-; §épilogue de la function:§
+; §épilogue de la fonction:§
 	lw	$28,16($fp)
 ; §mettre la valeur de retour à 0:§
 	move	$2,$0

--- a/patterns/03_printf/MIPS/printf3.O3.IDA_FR.lst
+++ b/patterns/03_printf/MIPS/printf3.O3.IDA_FR.lst
@@ -19,12 +19,12 @@
 .text:00000024                 li      $a2, 2
 ; appeler printf():
 .text:00000028                 jalr    $t9
-; §mettre le 4ème argument de printf(): (slot de retard de branchement)§
+; §mettre le 4ème argument de printf(): (slot de délai de branchement)§
 .text:0000002C                 li      $a3, 3
-; §épilogue de la function:§
+; §épilogue de la fonction:§
 .text:00000030                 lw      $ra, 0x20+var_4($sp)
 ; §mettre la valeur de retour à 0:§
 .text:00000034                 move    $v0, $zero
 ; retourner
 .text:00000038                 jr      $ra
-.text:0000003C                 addiu   $sp, 0x20 ; slot de retard de branchement
+.text:0000003C                 addiu   $sp, 0x20 ; §slot de délai de branchement§

--- a/patterns/03_printf/MIPS/printf3.O3_FR.s
+++ b/patterns/03_printf/MIPS/printf3.O3_FR.s
@@ -17,13 +17,13 @@ main:
 	li	$6,2			# 0x2
 ; appeler printf():
 	jalr	$25
-; §mettre le 4ème argument de printf() (slot de retard de branchement):§
+; §mettre le 4ème argument de printf() (slot de délai branchement):§
 	li	$7,3			# 0x3
 
-; §épilogue de la function:§
+; §épilogue de la fonction:§
 	lw	$31,28($sp)
 ; §mettre la valeur de retour à 0:§
 	move	$2,$0
 ; retourner
 	j	$31
-	addiu	$sp,$sp,32 ; branch delay slot
+	addiu	$sp,$sp,32 ; §slot de délai de branchement§

--- a/patterns/03_printf/MIPS/printf8.O0.IDA_FR.lst
+++ b/patterns/03_printf/MIPS/printf8.O0.IDA_FR.lst
@@ -46,7 +46,7 @@
 .text:00000064                 move    $t9, $v0
 .text:00000068                 jalr    $t9
 .text:0000006C                 or      $at, $zero ; NOP
-; §épilogue de la function:§
+; §épilogue de la fonction:§
 .text:00000070                 lw      $gp, 0x38+var_10($fp)
 ; §mettre la valeur de retour à 0:§
 .text:00000074                 move    $v0, $zero

--- a/patterns/03_printf/MIPS/printf8.O0_FR.s
+++ b/patterns/03_printf/MIPS/printf8.O0_FR.s
@@ -39,7 +39,7 @@ main:
 	move	$25,$2
 	jalr	$25
 	nop
-; §épilogue de la function:§
+; §épilogue de la fonction:§
 	lw	$28,40($fp)
 ; §mettre la valeur de retour à 0:§
 	move	$2,$0

--- a/patterns/03_printf/MIPS/printf8.O3.IDA_FR.lst
+++ b/patterns/03_printf/MIPS/printf8.O3.IDA_FR.lst
@@ -27,7 +27,7 @@
 .text:0000002C                 li      $v0, 7
 .text:00000030                 lw      $t9, (printf & 0xFFFF)($gp)
 .text:00000034                 sw      $v0, 0x38+var_1C($sp)
-; preparer le 1er argument dans $a0: 
+; §préparer le 1er argument dans \$a0:§ 
 .text:00000038                 lui     $a0, ($LC0 >> 16)  # "a=%d; b=%d; c=%d; d=%d; e=%d; f=%d; g=%"...
 ; §passer le 9ème argument dans la pile:§
 .text:0000003C                 li      $v0, 8
@@ -40,12 +40,12 @@
 .text:0000004C                 li      $a2, 2
 ; appeler printf():
 .text:00000050                 jalr    $t9
-; §passer le 4ème argument dans§ $a3 (slot de retard de branchement):
+; §passer le 4ème argument dans \$a3 (slot de délai de branchement):§
 .text:00000054                 li      $a3, 3
-; §épilogue de la function:§
+; §épilogue de la fonction:§
 .text:00000058                 lw      $ra, 0x38+var_4($sp)
 ; §mettre la valeur de retour à 0:§
 .text:0000005C                 move    $v0, $zero
 ; retourner
 .text:00000060                 jr      $ra
-.text:00000064                 addiu   $sp, 0x38 ; branch delay slot
+.text:00000064                 addiu   $sp, 0x38 ; §slot de délai de branchement§

--- a/patterns/03_printf/MIPS/printf8.O3_FR.s
+++ b/patterns/03_printf/MIPS/printf8.O3_FR.s
@@ -31,13 +31,13 @@ main:
 	li	$6,2			# 0x2
 ; appeler printf():
 	jalr	$25
-; §passer le 4ème argument dans§ $a3 (slot de retard de branchement):
+; §passer le 4ème argument dans \$a3 (slot de délai de branchement):§
 	li	$7,3			# 0x3
 
-; §épilogue de la function:§
+; §épilogue de la fonction:§
 	lw	$31,52($sp)
 ; §mettre la valeur de retour à 0:§
 	move	$2,$0
 ; retourner
 	j	$31
-	addiu	$sp,$sp,56 ; branch delay slot
+	addiu	$sp,$sp,56 ; §slot de délai de branchement§

--- a/patterns/04_scanf/1_simple/MIPS/ex1.O3.IDA_FR.lst
+++ b/patterns/04_scanf/1_simple/MIPS/ex1.O3.IDA_FR.lst
@@ -19,20 +19,20 @@
 .text:00000024          lw      $gp, 0x28+var_18($sp)
 .text:00000028          lui     $a0, ($LC1 >> 16)  # "%d"
 .text:0000002C          lw      $t9, (__isoc99_scanf & 0xFFFF)($gp)
-; §définir le 2nd argument de scanf(), $a1=$sp+24:§
+; §définir le 2nd argument de scanf(), \$a1=\$sp+24:§
 .text:00000030          addiu   $a1, $sp, 0x28+var_10
 .text:00000034          jalr    $t9  ; §slot de délai de branchement§
 .text:00000038          la      $a0, ($LC1 & 0xFFFF)  # "%d"
 ; appel de printf():
 .text:0000003C          lw      $gp, 0x28+var_18($sp)
 ; §définir le 2nd argument de printf(),§
-; §charger un mot à l'adresse $sp+24:§
+; §charger un mot à l'adresse \$sp+24:§
 .text:00000040          lw      $a1, 0x28+var_10($sp)
 .text:00000044          lw      $t9, (printf & 0xFFFF)($gp)
 .text:00000048          lui     $a0, ($LC2 >> 16)  # "You entered %d...\n"
 .text:0000004C          jalr    $t9
 .text:00000050          la      $a0, ($LC2 & 0xFFFF)  # "You entered %d...\n" ; §slot de délai de branchement§
-; §épilogue de la function:§
+; §épilogue de la fonction:§
 .text:00000054          lw      $ra, 0x28+var_4($sp)
 ; §mettre la valeur de retour à 0:§
 .text:00000058          move    $v0, $zero

--- a/patterns/04_scanf/1_simple/MIPS/ex1.O3_FR.s
+++ b/patterns/04_scanf/1_simple/MIPS/ex1.O3_FR.s
@@ -19,7 +19,7 @@ main:
 	lw	$28,16($sp)
 	lui	$4,%hi($LC1)
 	lw	$25,%call16(__isoc99_scanf)($28)
-; §définir le 2nd argument de scanf(), $a1=$sp+24:§
+; §définir le 2nd argument de scanf(), \$a1=\$sp+24:§
 	addiu	$5,$sp,24
 	jalr	$25
 	addiu	$4,$4,%lo($LC1) ; §slot de délai de branchement§
@@ -27,7 +27,7 @@ main:
 ; appel de printf():
 	lw	$28,16($sp)
 ; §définir le 2nd argument de printf(),§
-; §charger un mot à l'adresse $sp+24:§
+; §charger un mot à l'adresse \$sp+24:§
 	lw	$5,24($sp)
 	lw	$25,%call16(printf)($28)
 	lui	$4,%hi($LC2)

--- a/patterns/04_scanf/2_global/ARM64_GCC491_O0_FR.s
+++ b/patterns/04_scanf/2_global/ARM64_GCC491_O0_FR.s
@@ -8,7 +8,7 @@
 f5:
 ; sauver FP et LR dans la structure de pile locale:
 	stp	x29, x30, [sp, -16]!
-; set stack frame (FP=SP)
+; §définir la pile locale§ (FP=SP)
 	add	x29, sp, 0
 ; §charger le pointeur sur la chaîne§ "Enter X:":
 	adrp	x0, .LC0

--- a/patterns/04_scanf/2_global/MIPS/O3_IDA_FR.lst
+++ b/patterns/04_scanf/2_global/MIPS/O3_IDA_FR.lst
@@ -3,7 +3,7 @@
 .text:004006C0 var_10          = -0x10
 .text:004006C0 var_4           = -4
 .text:004006C0
-; prologue de la function:
+; prologue de la fonction:
 .text:004006C0                 lui     $gp, 0x42
 .text:004006C4                 addiu   $sp, -0x20
 .text:004006C8                 li      $gp, 0x418940
@@ -18,7 +18,7 @@
 .text:004006E4                 lw      $gp, 0x20+var_10($sp)
 .text:004006E8                 lui     $a0, 0x40
 .text:004006EC                 la      $t9, __isoc99_scanf
-; preparer l'adresse de x:
+; §préparer l'adresse de x:§
 .text:004006F0                 la      $a1, x
 .text:004006F4                 jalr    $t9 ; __isoc99_scanf
 .text:004006F8                 la      $a0, aD          # "%d"       ; §slot de délai de branchement§
@@ -40,7 +40,7 @@
 
 ...
 
-.sbss:0041099C  # Type de segment: Non initialisé
+.sbss:0041099C  # §Type de segment: Non initialisé§
 .sbss:0041099C                 .sbss
 .sbss:0041099C                 .globl x
 .sbss:0041099C x:              .space 4

--- a/patterns/05_passing_arguments/x64_GCC_FR.s
+++ b/patterns/05_passing_arguments/x64_GCC_FR.s
@@ -1,7 +1,7 @@
 f:
 	; EDI - 1er argument
-	; ESI - 2ème argument
-	; EDX - 3ème argument
+	; ESI - §2ème argument§
+	; EDX - §3ème argument§
 	push	rbp
 	mov	rbp, rsp
 	mov	DWORD PTR [rbp-4], edi
@@ -23,7 +23,7 @@ main:
 	mov	eax, OFFSET FLAT:.LC0 ; "%d\n"
 	mov	esi, edx
 	mov	rdi, rax
-	mov	eax, 0  ; nombre de registres vectoriel passés
+	mov	eax, 0  ; §nombre de registres vectoriel passés§
 	call	printf
 	mov	eax, 0
 	leave

--- a/patterns/05_passing_arguments/x64_GCC_O3_FR.s
+++ b/patterns/05_passing_arguments/x64_GCC_O3_FR.s
@@ -1,7 +1,7 @@
 f:
 	; EDI - 1er argument
-	; ESI - 2ème argument
-	; EDX - 3ème argument
+	; ESI - §2ème argument§
+	; EDX - §3ème argument§
 	imul	esi, edi
 	lea	eax, [rdx+rsi]
 	ret
@@ -14,7 +14,7 @@ main:
 	call	f
 	mov	edi, OFFSET FLAT:.LC0 ; "%d\n"
 	mov	esi, eax
-	xor	eax, eax  ; nombre de registres vectoriel passés
+	xor	eax, eax  ; §nombre de registres vectoriel passés§
 	call	printf
 	xor	eax, eax
 	add	rsp, 8


### PR DESCRIPTION
Missing escape for "$" inside "§" boundary
Missing escape in listing
Minor translation update
Typos