### PR TITLE
Fix a compilation error resulting from limited register arrays in TeX

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,5 +1,8 @@
 \documentclass[a4paper,oneside]{book}
 
+% http://www.tex.ac.uk/FAQ-noroom.html
+\usepackage{etex}
+
 \usepackage[table,usenames,dvipsnames]{xcolor}
 
 \usepackage{fontspec}


### PR DESCRIPTION
Without this patch I see the following error on a Fedora 24 system running TeX
Live 2015,

```
$ make
...
(./patterns/12_FPU/3_comparison/x86/MSVC/MSVC_RU.asm) [217] (./C3_in_AX.tex
! No room for a new \dimen .
\ch@ck ...\else \errmessage {No room for a new #3}
```

Thanks.