### PR TITLE
German: tiny corrections

### DIFF
--- a/patterns/12_FPU/3_comparison/x86/GCC_DE.tex
+++ b/patterns/12_FPU/3_comparison/x86/GCC_DE.tex
@@ -52,7 +52,7 @@ nach \ZF, \PF und \CF.
 \end{itemize}
 % TODO: table?
 Mit anderen Worten, die folgenden Zustände der CPU Flags sind nach drei
-\FUCMPP/\FNSTSW/\SAHF Befehlen möglich:
+\FUCOMPP/\FNSTSW/\SAHF Befehlen möglich:
 
 \begin{itemize}
 \item Falls $a>b$, werden die CPU Flags wie folgt gesetzt \GTT{ZF=0, PF=0,

--- a/patterns/12_FPU/3_comparison/x86/main.tex
+++ b/patterns/12_FPU/3_comparison/x86/main.tex
@@ -3,16 +3,21 @@
 % subsubsections
 \EN{\input{patterns/12_FPU/3_comparison/x86/MSVC/main_EN}}
 \RU{\input{patterns/12_FPU/3_comparison/x86/MSVC/main_RU}}
+\DE{\input{patterns/12_FPU/3_comparison/x86/MSVC/main_DE}}
 
 \EN{\input{patterns/12_FPU/3_comparison/x86/MSVC_Ox/main_EN}}
 \RU{\input{patterns/12_FPU/3_comparison/x86/MSVC_Ox/main_RU}}
+\DE{\input{patterns/12_FPU/3_comparison/x86/MSVC_Ox/main_DE}}
 
 \EN{\input{patterns/12_FPU/3_comparison/x86/GCC_EN}}
 \RU{\input{patterns/12_FPU/3_comparison/x86/GCC_RU}}
+\DE{\input{patterns/12_FPU/3_comparison/x86/GCC_DE}}
 
 \EN{\input{patterns/12_FPU/3_comparison/x86/GCC_O3_EN}}
 \RU{\input{patterns/12_FPU/3_comparison/x86/GCC_O3_RU}}
+\DE{\input{patterns/12_FPU/3_comparison/x86/GCC_O3_DE}}
 
 \EN{\input{patterns/12_FPU/3_comparison/x86/GCC481_O3_EN}}
 \RU{\input{patterns/12_FPU/3_comparison/x86/GCC481_O3_RU}}
+\DE{\input{patterns/12_FPU/3_comparison/x86/GCC481_O3_DE}}
 


### PR DESCRIPTION
Some translated files were not included in the book.
Typo in an instruction.