### PR TITLE
Typo: duplicate word

### DIFF
--- a/patterns/04_scanf/2_global/ex2_global_vars_ARM_EN.tex
+++ b/patterns/04_scanf/2_global/ex2_global_vars_ARM_EN.tex
@@ -28,7 +28,7 @@ must be saved somewhere in close proximity to the code.
 
 The \INS{LDR} instruction in Thumb mode can only address variables in a range of 1020 bytes from its location, 
 
-and in in ARM-mode~---variables in range of $\pm{}4095$ bytes.
+and in ARM-mode~---variables in range of $\pm{}4095$ bytes.
 
 And so the address of the \TT{x} variable
 must be located somewhere in close proximity, because there is no guarantee that the linker would be able to accommodate the variable somewhere nearby the code, it may well be even in an external memory chip!

--- a/patterns/12_FPU/3_comparison/ARM/ARM32_EN.tex
+++ b/patterns/12_FPU/3_comparison/ARM/ARM32_EN.tex
@@ -21,7 +21,7 @@ So there is \INS{VMRS}, which copies 4 bits (N, Z, C, V) from the coprocessor st
 \INS{VMOVGT} is the analog of the \INS{MOVGT}, 
 instruction for D-registers, it executes if one operand is greater than the other while comparing (\IT{GT---Greater Than}). 
 
-If it gets executed, the value of $a$ is to be written into \GTT{D16} (that is currently stored in in \GTT{D17}).
+If it gets executed, the value of $a$ is to be written into \GTT{D16} (that is currently stored in \GTT{D17}).
 Otherwise the value of $b$ stays in the \GTT{D16} register.
 
 \myindex{ARM!\Instructions!VMOV}


### PR DESCRIPTION
Just removed one.