### PR TITLE
French: remove non-ASCII characters from C code

### DIFF
--- a/patterns/13_arrays/45_month_1D/main_FR.tex
+++ b/patterns/13_arrays/45_month_1D/main_FR.tex
@@ -1,7 +1,11 @@
 ﻿\subsection{Tableau de pointeurs sur des chaînes}
 \label{array_of_pointers_to_strings}
 
-Voici un exemple de tableau de pointeurs.
+Voici un exemple de tableau de pointeurs.\footnote{NDT: attention à l'encodage des
+fichiers, en ASCII ou en ISO-8859, un caractère occupe un octet, alors qu'en UTF-8,
+notamment, il peut en occuper plusieurs. Par exemple, 'û' est codé \$fb (1 octet)
+en ISO-8859 et \$c3\$bb (2 octets) en UTF-8. J'ai donc volontairement mis des caractères
+non accentués dans le code.}
 
 \lstinputlisting[caption=Get month name,label=get_month1,style=customc]{patterns/13_arrays/45_month_1D/month1_FR.c}
 
@@ -215,7 +219,8 @@ il n'est utilisé que pour des sessions de debug.
 
 \subsubsection{Accèder à un caractère spécifique}
 
-Un tableau de pointeurs sur des chaînes peut être accèdé comme ceci:
+Un tableau de pointeurs sur des chaînes peut être accèdé comme ceci\footnote{Lisez
+l'avertissement dans la NDT ici \myref{array_of_pointers_to_strings}}:
 
 \lstinputlisting[style=customc]{patterns/13_arrays/45_month_1D/month2_FR.c}
 

--- a/patterns/13_arrays/45_month_1D/month1_FR.c
+++ b/patterns/13_arrays/45_month_1D/month1_FR.c
@@ -2,9 +2,9 @@
 
 const char* month1[]=
 {
-	"janvier", "février", "mars", "avril",
-	"mai", "juin", "juillet", "août",
-	"septembre", "octobre", "novembre", "décembre"
+	"janvier", "fevrier", "mars", "avril",
+	"mai", "juin", "juillet", "aout",
+	"septembre", "octobre", "novembre", "decembre"
 };
 
 // dans l'intervalle 0..11

--- a/patterns/13_arrays/45_month_1D/month2_FR.c
+++ b/patterns/13_arrays/45_month_1D/month2_FR.c
@@ -2,9 +2,9 @@
 
 const char* month[]=
 {
-	"janvier", "février", "mars", "avril",
-	"mai", "juin", "juillet", "août",
-	"septembre", "octobre", "novembre", "décembre"
+	"janvier", "fevrier", "mars", "avril",
+	"mai", "juin", "juillet", "aout",
+	"septembre", "octobre", "novembre", "decembre"
 };
 
 int main()


### PR DESCRIPTION
To avoid issue with encoding.
Add a footnote to warn about this.
