### PR TITLE
FRENCH : OS/calling_conventions

### DIFF
--- a/OS/calling_conventions/main_FR.tex
+++ b/OS/calling_conventions/main_FR.tex
@@ -53,7 +53,7 @@ int __stdcall f2 (int a, int b, int c)
 
 Le résultat de la compilation sera quasiment identique à celui de \myref{src:passing_arguments_ex_MSVC_cdecl}, 
 mais vous constatez la présence de \TT{RET 12} au lieu de \TT{RET}.
-\acLe \gls{caller} ne met pas à jour {SP} après l'appel.
+Le \gls{caller} ne met pas à jour {SP} après l'appel.
 
 Avec la convention \TT{\_\_stdcall}, on peut facilement déduire le nombre d'arguments de la fonction 
 appelée à partir de l'instruction \TT{RETN n}: divisez $n$ par 4.
@@ -119,7 +119,7 @@ int __fastcall f3 (int a, int b, int c)
 
 Le résultat de la compilation est le suivant:
 
-\lstinputlisting[caption=\MSVC 2010 optimisé/Ob0,style=customasmx86]{OS/calling_conventions/fastcall_ex.asm}
+\lstinputlisting[caption=MSVC 2010 optimisé/Ob0,style=customasmx86]{OS/calling_conventions/fastcall_ex.asm}
 
 Nous voyons que le \gls{callee} ajuste \ac{SP} en utilisant l'instruction \TT{RETN} suivie d'un opérande.
 
@@ -152,7 +152,7 @@ fonction afin de les distinguer de celles qui utilisent une autre convention d'a
 \subsection{thiscall}
 \myindex{thiscall}
 
-This is passing the object's \ITthis pointer to the function-method, in \Cpp.
+Cette convention passe le pointeur d'objet \ITthis à une méthode en \Cpp.
 
 Le compilateur MSVC, passe généralement le pointeur \ITthis dans le registre \ECX.
 
@@ -169,87 +169,95 @@ Pour un example, voir (\myref{thiscall}).
 \subsubsection{Windows x64}
 \label{sec:callingconventions_win64}
 
-The method of for passing arguments in Win64 somewhat resembles \TT{fastcall}.
-The first 4 arguments are passed via \RCX, \RDX, \Reg{8} and \Reg{9}, the rest---via the stack.
-The \gls{caller} also must prepare space for 32 bytes or 4 64-bit values,
-so then the \gls{callee} can save there the first 4 arguments.
-Short functions may use the arguments' values just from the registers,
-but larger ones may save their values for further use.
+La méthode utilisée pour passer les arguments aux fonctions en environnement Win64 ressemble 
+beaucoup à la convention \TT{fastcall}.
+Les 4 premiers arguments sont passés dans les registres \RCX, \RDX, \Reg{8} et \Reg{9}, 
+les arguments suivants sont passés sur la pile.
+Le \gls{caller} doit également préparer un espace sur la pile pour 32 octets, soit 4 mots de 64 bits, 
+le \gls{callee} pourra y sauvegarder les 4 premiers arguments.
+Les fonctions suffisamment simples peuvent utiliser les paramètres directement depuis les registres. 
+Les fonctions plus complexes doivent sauvegarder les valeurs de paramètres afin de les utiliser plus tard.
 
-The \gls{caller} also must return the \gls{stack pointer} into its initial state.
+Le \gls{caller} est aussi responsable de rétablir la valeur du \gls{stack pointer} à la valeur qu'il 
+avait avant l'appel de la fonction.
 
-This calling convention is also used in Windows x86-64 system DLLs 
-(instead of \IT{stdcall} in win32).
+Cette convention est utilisée dans les DLLs Windows x86-64 (à la place de \IT{stdcall} en win32).
 
-Example:
+Exemple:
 
 \lstinputlisting[style=customc]{OS/calling_conventions/x64.c}
 
 \lstinputlisting[caption=MSVC 2012 /0b,style=customasmx86]{OS/calling_conventions/x64_MSVC_Ob.asm}
 
-\myindex{Scratch space}
+\myindex{Espace de travail}
 
-Here we clearly see how 7 arguments are passed: 4 via registers and the remaining 3 via the stack.
+Nous vyons ici clairement que des 7 arguments, 4 sont passés dans les registres et les 3 suivants sur 
+la pile.
 
-The code of the f1() function's prologue saves the arguments in the \q{scratch space}---a space in the stack
-intended exactly for this purpose.
+Le prologue du code de la fonction f1() sauvegarde les arguments dans le \q{scratch space}---un espace 
+sur la pile précisément prévu à cet effet.
 
-This is arranged so because the compiler cannot be sure that there will be enough registers to use without these 4,
-which will otherwise be occupied by the arguments until the function's execution end.
+Le compilateur agit ainsi car il n'est pas certain par avance qu'il disposera de suffisamment de
+registres pour toute la fonction en l'absence des 4 utilisés par les paramètres.
 
-The \q{scratch space} allocation in the stack is the caller's duty.
+L'appelant est responsable de l'allocation du \q{scratch space} sur la pile.
 
 \lstinputlisting[caption=\Optimizing MSVC 2012 /0b,style=customasmx86]{OS/calling_conventions/x64_MSVC_Ox_Ob.asm}
 
-If we compile the example with optimizations, it is to be almost the same, 
-but the \q{scratch space} will not be used, because it won't be needed.
+L'exemple compilé en branchant les optimisations, sera quasiment identique, si ce n'est que le 
+\q{scratch space} ne sera pas utilisé car inutile.
 
 \myindex{x86!\Instructions!LEA}
 \label{using_MOV_and_pack_of_LEA_to_load_values}
 
-Also take a look on how MSVC 2012 optimizes the loading of primitive values into registers by using \LEA (\myref{sec:LEA}).
-\INS{MOV} would be 1 byte longer here (5 instead of 4).
+Notez également la manière dont MSVC 2012 optimise le chargement de certaines valeurs litérales dans 
+les registres en utilisant \LEA (\myref{sec:LEA}).
+L'instruction \INS{MOV} utiliserait 1 octet de plus (5 au lieu de 4).
 
-Another example of such thing is: \myref{TaskMgr_LEA}.
+\myref{TaskMgr_LEA} est un autre exemple de cette pratique.
 
-\myparagraph{Windows x64: Passing \ITthis (\CCpp)}
+\myparagraph{Windows x64: Passage de \ITthis (\CCpp)}
 
-The \ITthis pointer is passed in \RCX, the first argument of the method is in \RDX, etc.
-For an example see: \myref{simple_CPP_MSVC_x64}.
+Le pointeur \ITthis est passé dans le registre \RCX, le premier argument de la méthode dans \RDX, etc.
+Pour un exemple, voir : \myref{simple_CPP_MSVC_x64}.
  
 \subsubsection{Linux x64}
 
-The way arguments are passed in Linux for x86-64 is almost the same as in Windows, but 6 registers are
-used instead of 4 (\RDI, \RSI, \RDX, \RCX, \Reg{8}, \Reg{9}) and there is no \q{scratch space}, 
-although the \gls{callee} may save the register values in the stack, if it needs/wants to.
+Le passage d'arguments par Linux pour x86-64 est quasiment identique à celui de Windows, si ce n'est 
+que 6 registres sont utilisés au lieu de 4 (\RDI, \RSI, \RDX, \RCX, \Reg{8}, \Reg{9}) et qu'il n'existe
+pas de \q{scratch space}. Le \gls{callee} conserve la possibilité de sauvegarder les registres sur la 
+pile s'il le souhaite ou en a besoin.
 
-\lstinputlisting[caption=\Optimizing GCC 4.7.3,style=customasmx86]{OS/calling_conventions/x64_linux_O3.s}
+\lstinputlisting[caption=GCC 4.7.3 avec optimisation,style=customasmx86]{OS/calling_conventions/x64_linux_O3.s}
 
 \myindex{AMD}
 
-N.B.: here the values are written into the 32-bit parts of the registers (e.g., EAX) but not in the whole 64-bit 
-register (RAX).
-This is because each write to the low 32-bit part of a register automatically clears the high 32 bits.
-Supposedly, it was decided in AMD to do so to simplify porting code to x86-64.
+N.B.: Les valeurs sont enregistrées dans la partie basse des registres (e.g., EAX) et non pas dans la 
+totalité du registre 64 bits (RAX).
+Ceci s'explique par le fait que l'écriture des 32 bits de poids faible du registre remet automatiquement 
+à zéro les 32 bits de poids fort.
+On suppose qu'AMD a pris cette décision afin de simplifier le portage du code 32 bits vers l'architecture 
+x86-64.
 
-\subsection{Return values of \Tfloat and \Tdouble type}
+\subsection{Valeur de retour de type \Tfloat et \Tdouble}
 \myindex{float}
 \myindex{double}
 
-In all conventions except in Win64, the values of type \Tfloat or \Tdouble are returned via the FPU register \ST{0}.
+Dans toutes les conventions, à l'exception de l'environnement Win64, les valeurs de type \Tfloat ou 
+\Tdouble sont retournées dans le registre FPU \ST{0}.
 
-In Win64, the values of \Tfloat and \Tdouble types are returned 
-in the low 32 or 64 bits of the \XMM{0} register.
+En environnement Win64, les valeurs de type \Tfloat et \Tdouble sont respectivement retournées dans 
+les 32 bits de poids faible et dans les 64 bits du registre \XMM{0}.
 
-\subsection{Modifying arguments}
+\subsection{Modification des arguments}
 
-Sometimes, \CCpp{} programmers (not limited to these \ac{PL}s, though),
-may ask, what can happen if they modify the arguments?
+Il arrive que les programmeurs \CCpp{} (et ceux d'autres \ac{PL}s aussi) se demandent ce qui se passe 
+s'ils modifient la valeur des arguments dans la fonction appelée.
 
-The answer is simple: the arguments are stored in the stack, 
-that is where the modification takes place.
+La réponse est simple. Les arguments sont stockés sur la pile, et c'est elle qui est modifiée.
 
-The calling functions is not using them after the \gls{callee}'s exit (the author of these lines has never seen any such case in his practice).
+Une fois que le \gls{callee} s'achève, la fonction appelante ne les utilise pas.
+(L'auteur de ces lignes n'a jamais constaté qu'il en aille autrement).
 
 \lstinputlisting[style=customc]{OS/calling_conventions/change_arguments.c}
 
@@ -257,16 +265,16 @@ The calling functions is not using them after the \gls{callee}'s exit (the autho
 
 % TODO (OllyDbg) пример как в стеке меняется $a$
 
-So yes, one can modify the arguments easily.
-Of course, if it is not \IT{references} in \Cpp{} (\myref{cpp_references}),
-and if you don't modify data to which a pointer points to, 
-then the effect will not propagate outside the current function.
+Donc, oui, la valeur des arguments peut être modifiée sans problème.
+Sous réserver que l'argument ne soit pas une \IT{references} en \Cpp{} (\myref{cpp_references}),
+et que vous ne modifiez pas la valeur qui est référencée par un pointeur, l'effet de votre modification 
+ne se propagera pas au dehors de la fonction.
 
-Theoretically, after the \gls{callee}'s return, 
-the \gls{caller} could get the modified argument and use it somehow.
-Maybe if it is written directly in assembly language.
+En théorie, après le retour du \gls{callee}, le \gls{caller} pourrait récupérer l'argument modifié et 
+l'utiliser à sa guise.
+Ceci pourrait peut être se faire dans un programme rédigé en assembleur.
 
-For example, code like this will be generated by usual \CCpp compiler:
+Par exemple, un compilateur \CCpp génèrera un code comme celui-ci :
 
 \begin{lstlisting}[style=customasmx86]
 	push	456	; will be b
@@ -275,7 +283,7 @@ For example, code like this will be generated by usual \CCpp compiler:
 	add	esp, 2*4
 \end{lstlisting}
 
-We can rewrite this code like:
+Nous pouvons réécrire le code ainsi :
 
 \begin{lstlisting}[style=customasmx86]
 	push	456	; will be b
@@ -286,9 +294,10 @@ We can rewrite this code like:
 	; EAX=1st argument of f() modified in f()
 \end{lstlisting}
 
-Hard to imagine, why anyone would need this, but this is possible in practice.
-Nevertheless, the \CCpp languages standards don't offer any way to do so.
+Il est difficile d'imaginer pourquoi quelqu'un aurait besoin d'agir ainsi, mais en pratique 
+c'est possible.
+Toujours est-il que les langages \CCpp ne permettent pas de faire ainsi.
 
 % sections
-\input{OS/calling_conventions/ptr_to_argument/main_EN}
+\input{OS/calling_conventions/ptr_to_argument/main_FR}
 

--- a/OS/calling_conventions/ptr_to_argument/main_FR.tex
+++ b/OS/calling_conventions/ptr_to_argument/main_FR.tex
@@ -1,0 +1,37 @@
+﻿\subsection{Recevoir un argument par adresse}
+\label{pointer_to_argument}
+
+\dots mieux que cela, il est possible de passer à une fonction l'adresse d'un argument, plutôt que 
+la valeur de l'argument lui-même:
+
+\lstinputlisting[style=customc]{OS/calling_conventions/ptr_to_argument/10.c}
+
+Il est difficile de comprendre ce fonctionnement jusqu'à ce que l'on regarde le code:
+
+\lstinputlisting[caption=MSVC 2010 optimisé,style=customasmx86]{OS/calling_conventions/ptr_to_argument/MSVC_2010_O3.asm}
+
+L'argument $a$ est placé sur la pile et l'adresse de cet emplacement de pile est passé à une autre
+fonction. Celle-ci modifie la valeur à l'adresse référencée par le pointeur, puis \printf affiche 
+la valeur après modification.
+
+\par Le lecteur attentif se demandera peut-être ce qu'il en est avec les conventions d'appel qui 
+utilisent les registres pour passer les arguments.
+
+C'est justement une des utilisations du \IT{Shadow Space}.
+
+La valeur en entrée est copiée du registre vers le \IT{Shadow Space} dans la pile locale, puis 
+l'adresse de la pile locale est passée à la fonction appelée:
+
+\lstinputlisting[caption=MSVC 2012 x64 optimisé,style=customasmx86]{OS/calling_conventions/ptr_to_argument/MSVC_2012_x64_O3.asm}
+
+Le compilateur GCC lui aussi sauvegarde la valeur sur la pile locale:
+
+\lstinputlisting[caption=GCC 4.9.1 optimisé x64,style=customasmx86]{OS/calling_conventions/ptr_to_argument/GCC491_x64_O3.s}
+
+Le compilateur GCC pour ARM64 se comporte de la même manière, mais l'espace de sauvegarde sur la pile 
+est dénommé \IT{Register Save Area} :
+
+\lstinputlisting[caption=GCC 4.9.1 optimisé ARM64,style=customasmARM]{OS/calling_conventions/ptr_to_argument/GCC49_ARM64_O3.s}
+
+Enfin, nous constatons un usage similaire du \IT{Shadow Space} ici: \myref{variadic_arith_registers}.
+

--- a/OS/main.tex
+++ b/OS/main.tex
@@ -2,6 +2,7 @@
 \EN{\input{OS/calling_conventions/main_EN}}
 \RU{\input{OS/calling_conventions/main_RU}}
 \DE{\input{OS/calling_conventions/main_DE}}
+\FR{\input{OS/calling_conventions/main_FR}}
 
 \input{OS/TLS/main}
 


### PR DESCRIPTION
1) There is a sentence that I didn't translate because I couldn't understand 
the underlying idea :

Thus it will be very visible that internally: all function-methods have an extra argument.

Should you explain your intent, I will fix it on next round.

2) You say you can't imagine why someone would devise a function where the 
caller would mess up with the stack in order to retrieve the result of a 
parameter value modification. Actually this is a scheme that is sometimes 
used for obfuscation purpose, most notably in software copy prevention and 
licence enforcement. This can be particularly effective if most of the time 
the caller sticks to the calling convention and, from time to time, in non 
obvious manner, manage to retrieve such a modification ...