### PR TITLE
German: patterns/14_bitfields use translated files

### DIFF
--- a/patterns/14_bitfields/1_check/main.tex
+++ b/patterns/14_bitfields/1_check/main.tex
@@ -2,6 +2,8 @@
 
 \EN{\input{patterns/14_bitfields/1_check/x86_EN}}
 \RU{\input{patterns/14_bitfields/1_check/x86_RU}}
+\DE{\input{patterns/14_bitfields/1_check/x86_DE}}
 \EN{\input{patterns/14_bitfields/1_check/ARM_EN}}
 \RU{\input{patterns/14_bitfields/1_check/ARM_RU}}
+\DE{\input{patterns/14_bitfields/1_check/ARM_DE}}
 

--- a/patterns/14_bitfields/2_set_reset/main.tex
+++ b/patterns/14_bitfields/2_set_reset/main.tex
@@ -6,8 +6,11 @@
 
 \EN{\input{patterns/14_bitfields/2_set_reset/x86_EN}}
 \RU{\input{patterns/14_bitfields/2_set_reset/x86_RU}}
+\DE{\input{patterns/14_bitfields/2_set_reset/x86_DE}}
 \EN{\input{patterns/14_bitfields/2_set_reset/ARM_EN}}
 \RU{\input{patterns/14_bitfields/2_set_reset/ARM_RU}}
+\DE{\input{patterns/14_bitfields/2_set_reset/ARM_DE}}
 \EN{\input{patterns/14_bitfields/2_set_reset/MIPS_EN}}
 \RU{\input{patterns/14_bitfields/2_set_reset/MIPS_RU}}
+\DE{\input{patterns/14_bitfields/2_set_reset/MIPS_DE}}
 

--- a/patterns/14_bitfields/35_set_reset_FPU/main.tex
+++ b/patterns/14_bitfields/35_set_reset_FPU/main.tex
@@ -1,2 +1,3 @@
 \EN{\input{patterns/14_bitfields/35_set_reset_FPU/main_EN}}
 \RU{\input{patterns/14_bitfields/35_set_reset_FPU/main_RU}}
+\DE{\input{patterns/14_bitfields/35_set_reset_FPU/main_DE}}

--- a/patterns/14_bitfields/3_shifts/main.tex
+++ b/patterns/14_bitfields/3_shifts/main.tex
@@ -1,3 +1,4 @@
 \EN{\input{patterns/14_bitfields/3_shifts/main_EN}}
 \RU{\input{patterns/14_bitfields/3_shifts/main_RU}}
+\DE{\input{patterns/14_bitfields/3_shifts/main_DE}}
 

--- a/patterns/14_bitfields/4_popcnt/main.tex
+++ b/patterns/14_bitfields/4_popcnt/main.tex
@@ -1,3 +1,4 @@
 ﻿\EN{\input{patterns/14_bitfields/4_popcnt/main_EN}}
 \RU{\input{patterns/14_bitfields/4_popcnt/main_RU}}
+\DE{\input{patterns/14_bitfields/4_popcnt/main_DE}}
 

--- a/patterns/14_bitfields/main.tex
+++ b/patterns/14_bitfields/main.tex
@@ -1,3 +1,4 @@
 \EN{\input{patterns/14_bitfields/main_EN}}
 \RU{\input{patterns/14_bitfields/main_RU}}
+\DE{\input{patterns/14_bitfields/main_DE}}
 


### PR DESCRIPTION
Chapter is translated, but not used in the book.
Or there is a good reason not to use them!?